### PR TITLE
fix(oidc): #20 session flow uses id token instead of access token

### DIFF
--- a/backend/cmd/server/openapi.yaml
+++ b/backend/cmd/server/openapi.yaml
@@ -58,7 +58,7 @@ paths:
       tags: [Auth]
       summary: Get current user
       security:
-        - bearerAuth: []
+        - sessionCookie: []
       responses:
         '200':
           description: Current user info
@@ -74,7 +74,7 @@ paths:
       tags: [Categories]
       summary: List categories
       security:
-        - bearerAuth: []
+        - sessionCookie: []
       responses:
         '200':
           description: List of categories
@@ -88,7 +88,7 @@ paths:
       tags: [Categories]
       summary: Create category
       security:
-        - bearerAuth: []
+        - sessionCookie: []
       requestBody:
         required: true
         content:
@@ -108,7 +108,7 @@ paths:
       tags: [Categories]
       summary: Get category by ID
       security:
-        - bearerAuth: []
+        - sessionCookie: []
       parameters:
         - $ref: '#/components/parameters/id'
       responses:
@@ -124,7 +124,7 @@ paths:
       tags: [Categories]
       summary: Update category
       security:
-        - bearerAuth: []
+        - sessionCookie: []
       parameters:
         - $ref: '#/components/parameters/id'
       requestBody:
@@ -144,7 +144,7 @@ paths:
       tags: [Categories]
       summary: Delete category
       security:
-        - bearerAuth: []
+        - sessionCookie: []
       parameters:
         - $ref: '#/components/parameters/id'
       responses:
@@ -156,7 +156,7 @@ paths:
       tags: [Locations]
       summary: List locations
       security:
-        - bearerAuth: []
+        - sessionCookie: []
       responses:
         '200':
           description: List of locations
@@ -170,7 +170,7 @@ paths:
       tags: [Locations]
       summary: Create location
       security:
-        - bearerAuth: []
+        - sessionCookie: []
       requestBody:
         required: true
         content:
@@ -190,7 +190,7 @@ paths:
       tags: [Locations]
       summary: Get location by ID
       security:
-        - bearerAuth: []
+        - sessionCookie: []
       parameters:
         - $ref: '#/components/parameters/id'
       responses:
@@ -204,7 +204,7 @@ paths:
       tags: [Locations]
       summary: Update location
       security:
-        - bearerAuth: []
+        - sessionCookie: []
       parameters:
         - $ref: '#/components/parameters/id'
       requestBody:
@@ -220,7 +220,7 @@ paths:
       tags: [Locations]
       summary: Delete location
       security:
-        - bearerAuth: []
+        - sessionCookie: []
       parameters:
         - $ref: '#/components/parameters/id'
       responses:
@@ -232,7 +232,7 @@ paths:
       tags: [Conditions]
       summary: List conditions
       security:
-        - bearerAuth: []
+        - sessionCookie: []
       responses:
         '200':
           description: List of conditions
@@ -246,7 +246,7 @@ paths:
       tags: [Conditions]
       summary: Create condition
       security:
-        - bearerAuth: []
+        - sessionCookie: []
       requestBody:
         required: true
         content:
@@ -262,7 +262,7 @@ paths:
       tags: [Conditions]
       summary: Get condition by ID
       security:
-        - bearerAuth: []
+        - sessionCookie: []
       parameters:
         - $ref: '#/components/parameters/id'
       responses:
@@ -276,7 +276,7 @@ paths:
       tags: [Conditions]
       summary: Update condition
       security:
-        - bearerAuth: []
+        - sessionCookie: []
       parameters:
         - $ref: '#/components/parameters/id'
       requestBody:
@@ -292,7 +292,7 @@ paths:
       tags: [Conditions]
       summary: Delete condition
       security:
-        - bearerAuth: []
+        - sessionCookie: []
       parameters:
         - $ref: '#/components/parameters/id'
       responses:
@@ -304,7 +304,7 @@ paths:
       tags: [Assets]
       summary: List assets
       security:
-        - bearerAuth: []
+        - sessionCookie: []
       parameters:
         - name: q
           in: query
@@ -347,7 +347,7 @@ paths:
       tags: [Assets]
       summary: Create asset
       security:
-        - bearerAuth: []
+        - sessionCookie: []
       requestBody:
         required: true
         content:
@@ -367,7 +367,7 @@ paths:
       tags: [Assets]
       summary: Get asset by ID
       security:
-        - bearerAuth: []
+        - sessionCookie: []
       parameters:
         - $ref: '#/components/parameters/id'
       responses:
@@ -381,7 +381,7 @@ paths:
       tags: [Assets]
       summary: Update asset
       security:
-        - bearerAuth: []
+        - sessionCookie: []
       parameters:
         - $ref: '#/components/parameters/id'
       requestBody:
@@ -397,7 +397,7 @@ paths:
       tags: [Assets]
       summary: Delete asset
       security:
-        - bearerAuth: []
+        - sessionCookie: []
       parameters:
         - $ref: '#/components/parameters/id'
       responses:
@@ -409,7 +409,7 @@ paths:
       tags: [Warranties]
       summary: Get asset warranty
       security:
-        - bearerAuth: []
+        - sessionCookie: []
       parameters:
         - $ref: '#/components/parameters/id'
       responses:
@@ -425,7 +425,7 @@ paths:
       tags: [Warranties]
       summary: Create warranty for asset
       security:
-        - bearerAuth: []
+        - sessionCookie: []
       parameters:
         - $ref: '#/components/parameters/id'
       requestBody:
@@ -441,7 +441,7 @@ paths:
       tags: [Warranties]
       summary: Update asset warranty
       security:
-        - bearerAuth: []
+        - sessionCookie: []
       parameters:
         - $ref: '#/components/parameters/id'
       requestBody:
@@ -457,7 +457,7 @@ paths:
       tags: [Warranties]
       summary: Delete asset warranty
       security:
-        - bearerAuth: []
+        - sessionCookie: []
       parameters:
         - $ref: '#/components/parameters/id'
       responses:
@@ -469,7 +469,7 @@ paths:
       tags: [Warranties]
       summary: List expiring warranties
       security:
-        - bearerAuth: []
+        - sessionCookie: []
       parameters:
         - name: days
           in: query
@@ -492,7 +492,7 @@ paths:
       tags: [Attachments]
       summary: List asset attachments
       security:
-        - bearerAuth: []
+        - sessionCookie: []
       parameters:
         - $ref: '#/components/parameters/id'
       responses:
@@ -508,7 +508,7 @@ paths:
       tags: [Attachments]
       summary: Upload attachment
       security:
-        - bearerAuth: []
+        - sessionCookie: []
       parameters:
         - $ref: '#/components/parameters/id'
       requestBody:
@@ -530,7 +530,7 @@ paths:
       tags: [Attachments]
       summary: Get attachment download URL
       security:
-        - bearerAuth: []
+        - sessionCookie: []
       parameters:
         - name: attachmentId
           in: path
@@ -553,7 +553,7 @@ paths:
       tags: [Attachments]
       summary: Delete attachment
       security:
-        - bearerAuth: []
+        - sessionCookie: []
       parameters:
         - name: attachmentId
           in: path
@@ -567,11 +567,11 @@ paths:
 
 components:
   securitySchemes:
-    bearerAuth:
-      type: http
-      scheme: bearer
-      bearerFormat: JWT
-      description: JWT token from Keycloak OIDC
+    sessionCookie:
+      type: apiKey
+      in: cookie
+      name: session
+      description: OIDC session cookie set after a successful login
 
   parameters:
     id:

--- a/backend/internal/auth/middleware.go
+++ b/backend/internal/auth/middleware.go
@@ -24,9 +24,28 @@ type Claims struct {
 	DisplayName string `json:"preferred_username"`
 }
 
+// TokenVerifier verifies OIDC tokens.
+type TokenVerifier interface {
+	Verify(context.Context, string) (VerifiedToken, error)
+}
+
+// VerifiedToken exposes the claims needed by the auth middleware.
+type VerifiedToken interface {
+	Claims(v interface{}) error
+	Subject() string
+}
+
+type oidcTokenVerifier struct {
+	verifier *oidc.IDTokenVerifier
+}
+
+type oidcVerifiedToken struct {
+	token *oidc.IDToken
+}
+
 // Middleware handles authentication (both OIDC and local)
 type Middleware struct {
-	verifier       *oidc.IDTokenVerifier
+	verifier       TokenVerifier
 	disabled       bool
 	oidcEnabled    bool
 	oauth          *OAuthHandler
@@ -60,13 +79,9 @@ func NewMiddleware(ctx context.Context, cfg Config) (*Middleware, error) {
 		}
 
 		verifier := provider.Verifier(&oidc.Config{
-			ClientID:                   cfg.ClientID,
-			SkipClientIDCheck:          true, // Keycloak access tokens use 'azp' not 'aud'
-			SkipExpiryCheck:            false,
-			SkipIssuerCheck:            false,
-			InsecureSkipSignatureCheck: false,
+			ClientID: cfg.ClientID,
 		})
-		m.verifier = verifier
+		m.verifier = &oidcTokenVerifier{verifier: verifier}
 	}
 
 	return m, nil
@@ -123,7 +138,7 @@ func (m *Middleware) authenticateOIDC(w http.ResponseWriter, r *http.Request, ne
 
 	// If no header, try session cookie
 	if tokenString == "" && m.oauth != nil {
-		tokenString = m.oauth.GetAccessToken(r)
+		tokenString = m.oauth.GetIDToken(r)
 	}
 
 	if tokenString == "" {
@@ -147,9 +162,9 @@ func (m *Middleware) authenticateOIDC(w http.ResponseWriter, r *http.Request, ne
 		return
 	}
 
-	claims.Subject = idToken.Subject
+	claims.Subject = idToken.Subject()
 
-	// If claims are missing from access token, supplement from session cookie
+	// If claims are missing from the ID token, supplement from the session cookie
 	if (claims.Email == "" || claims.DisplayName == "") && m.oauth != nil {
 		session, _ := m.oauth.getSessionFromCookie(r)
 		if session != nil {
@@ -214,6 +229,23 @@ func (m *Middleware) Optional(next http.Handler) http.Handler {
 		// If header is present, validate it
 		m.Authenticate(next).ServeHTTP(w, r)
 	})
+}
+
+func (v *oidcTokenVerifier) Verify(ctx context.Context, rawToken string) (VerifiedToken, error) {
+	token, err := v.verifier.Verify(ctx, rawToken)
+	if err != nil {
+		return nil, err
+	}
+
+	return &oidcVerifiedToken{token: token}, nil
+}
+
+func (t *oidcVerifiedToken) Claims(v interface{}) error {
+	return t.token.Claims(v)
+}
+
+func (t *oidcVerifiedToken) Subject() string {
+	return t.token.Subject
 }
 
 // RequireAdmin middleware checks if the user has admin role

--- a/backend/internal/auth/middleware.go
+++ b/backend/internal/auth/middleware.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"log/slog"
 	"net/http"
-	"strings"
 
 	"github.com/coreos/go-oidc/v3/oidc"
 	"github.com/lmmendes/attic/internal/domain"
@@ -126,18 +125,7 @@ func (m *Middleware) Authenticate(next http.Handler) http.Handler {
 // authenticateOIDC handles OIDC-based authentication
 func (m *Middleware) authenticateOIDC(w http.ResponseWriter, r *http.Request, next http.Handler) {
 	var tokenString string
-
-	// First, try Authorization header
-	authHeader := r.Header.Get("Authorization")
-	if authHeader != "" {
-		parts := strings.SplitN(authHeader, " ", 2)
-		if len(parts) == 2 && strings.EqualFold(parts[0], "bearer") {
-			tokenString = parts[1]
-		}
-	}
-
-	// If no header, try session cookie
-	if tokenString == "" && m.oauth != nil {
+	if m.oauth != nil {
 		tokenString = m.oauth.GetIDToken(r)
 	}
 
@@ -146,8 +134,8 @@ func (m *Middleware) authenticateOIDC(w http.ResponseWriter, r *http.Request, ne
 		return
 	}
 
-	// Verify the token
-	idToken, err := m.verifier.Verify(r.Context(), tokenString)
+	// Verify the ID token from the OIDC session.
+	verifiedToken, err := m.verifier.Verify(r.Context(), tokenString)
 	if err != nil {
 		slog.Error("token verification failed", "error", err)
 		http.Error(w, `{"error":"invalid token"}`, http.StatusUnauthorized)
@@ -156,15 +144,15 @@ func (m *Middleware) authenticateOIDC(w http.ResponseWriter, r *http.Request, ne
 
 	// Extract claims
 	var claims Claims
-	if err := idToken.Claims(&claims); err != nil {
+	if err := verifiedToken.Claims(&claims); err != nil {
 		slog.Error("failed to parse claims", "error", err)
 		http.Error(w, `{"error":"invalid token claims"}`, http.StatusUnauthorized)
 		return
 	}
 
-	claims.Subject = idToken.Subject()
+	claims.Subject = verifiedToken.Subject()
 
-	// If claims are missing from the ID token, supplement from the session cookie
+	// If claims are missing from the verified token, supplement from the session cookie.
 	if (claims.Email == "" || claims.DisplayName == "") && m.oauth != nil {
 		session, _ := m.oauth.getSessionFromCookie(r)
 		if session != nil {
@@ -215,20 +203,6 @@ func GetClaims(ctx context.Context) *Claims {
 		return nil
 	}
 	return claims
-}
-
-// Optional returns middleware that allows unauthenticated requests
-func (m *Middleware) Optional(next http.Handler) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		authHeader := r.Header.Get("Authorization")
-		if authHeader == "" {
-			next.ServeHTTP(w, r)
-			return
-		}
-
-		// If header is present, validate it
-		m.Authenticate(next).ServeHTTP(w, r)
-	})
 }
 
 func (v *oidcTokenVerifier) Verify(ctx context.Context, rawToken string) (VerifiedToken, error) {

--- a/backend/internal/auth/middleware_test.go
+++ b/backend/internal/auth/middleware_test.go
@@ -2,6 +2,8 @@ package auth
 
 import (
 	"context"
+	"encoding/base64"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -10,6 +12,26 @@ import (
 	"github.com/google/uuid"
 	"github.com/lmmendes/attic/internal/domain"
 )
+
+type mockTokenVerifier struct {
+	verifyFn func(context.Context, string) (VerifiedToken, error)
+}
+
+type mockVerifiedToken struct {
+	subject string
+}
+
+func (m *mockTokenVerifier) Verify(ctx context.Context, token string) (VerifiedToken, error) {
+	return m.verifyFn(ctx, token)
+}
+
+func (t *mockVerifiedToken) Claims(v interface{}) error {
+	return nil
+}
+
+func (t *mockVerifiedToken) Subject() string {
+	return t.subject
+}
 
 // Tests for disabled middleware
 
@@ -500,5 +522,62 @@ func Test_Middleware_Local_ExpiredSession_ReturnsUnauthorized(t *testing.T) {
 	}
 	if rec.Code != http.StatusUnauthorized {
 		t.Errorf("expected status 401, got %d", rec.Code)
+	}
+}
+
+func Test_Middleware_OIDC_UsesIDTokenFromSessionCookie(t *testing.T) {
+	session := Session{
+		AccessToken: "opaque-access-token",
+		IDToken:     "signed-id-token",
+		ExpiresAt:   time.Now().Add(1 * time.Hour),
+		Email:       "user@example.com",
+		Name:        "User Name",
+	}
+	data, err := json.Marshal(session)
+	if err != nil {
+		t.Fatalf("failed to marshal session: %v", err)
+	}
+	encoded := base64.StdEncoding.EncodeToString(data)
+
+	m := &Middleware{
+		oidcEnabled: true,
+		oauth:       &OAuthHandler{},
+		verifier: &mockTokenVerifier{
+			verifyFn: func(ctx context.Context, token string) (VerifiedToken, error) {
+				if token != "signed-id-token" {
+					t.Fatalf("expected ID token to be verified, got %q", token)
+				}
+				return &mockVerifiedToken{subject: "oidc-subject-123"}, nil
+			},
+		},
+	}
+
+	nextCalled := false
+	var claims *Claims
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		nextCalled = true
+		claims = GetClaims(r.Context())
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.AddCookie(&http.Cookie{Name: sessionCookieName, Value: encoded})
+	rec := httptest.NewRecorder()
+
+	m.Authenticate(next).ServeHTTP(rec, req)
+
+	if !nextCalled {
+		t.Fatal("expected next handler to be called")
+	}
+	if claims == nil {
+		t.Fatal("expected claims to be set")
+	}
+	if claims.Subject != "oidc-subject-123" {
+		t.Errorf("expected subject oidc-subject-123, got %s", claims.Subject)
+	}
+	if claims.Email != "user@example.com" {
+		t.Errorf("expected email user@example.com, got %s", claims.Email)
+	}
+	if claims.DisplayName != "User Name" {
+		t.Errorf("expected display name User Name, got %s", claims.DisplayName)
 	}
 }

--- a/backend/internal/auth/middleware_test.go
+++ b/backend/internal/auth/middleware_test.go
@@ -254,55 +254,6 @@ func Test_GetClaims_WithWrongType_ReturnsNil(t *testing.T) {
 	}
 }
 
-// Tests for Optional middleware
-
-func Test_Optional_NoAuthHeader_AllowsRequest(t *testing.T) {
-	m := &Middleware{disabled: false, oidcEnabled: false}
-
-	nextCalled := false
-	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		nextCalled = true
-		w.WriteHeader(http.StatusOK)
-	})
-
-	req := httptest.NewRequest(http.MethodGet, "/", nil)
-	rec := httptest.NewRecorder()
-
-	m.Optional(next).ServeHTTP(rec, req)
-
-	if !nextCalled {
-		t.Error("expected next handler to be called without auth header")
-	}
-	if rec.Code != http.StatusOK {
-		t.Errorf("expected status 200, got %d", rec.Code)
-	}
-}
-
-func Test_Optional_WithAuthHeader_ValidatesToken(t *testing.T) {
-	sm := NewSessionManager("test-secret", 24)
-	m := &Middleware{
-		disabled:       false,
-		oidcEnabled:    false,
-		sessionManager: sm,
-	}
-
-	nextCalled := false
-	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		nextCalled = true
-	})
-
-	req := httptest.NewRequest(http.MethodGet, "/", nil)
-	req.Header.Set("Authorization", "Bearer invalid-token")
-	rec := httptest.NewRecorder()
-
-	m.Optional(next).ServeHTTP(rec, req)
-
-	// Should try to validate the token and fail
-	if nextCalled {
-		t.Error("expected next handler NOT to be called with invalid token")
-	}
-}
-
 // Tests for RequireAdmin middleware
 
 func Test_RequireAdmin_NoSession_ReturnsUnauthorized(t *testing.T) {
@@ -560,6 +511,7 @@ func Test_Middleware_OIDC_UsesIDTokenFromSessionCookie(t *testing.T) {
 	})
 
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("Authorization", "Bearer opaque-access-token")
 	req.AddCookie(&http.Cookie{Name: sessionCookieName, Value: encoded})
 	rec := httptest.NewRecorder()
 
@@ -579,5 +531,36 @@ func Test_Middleware_OIDC_UsesIDTokenFromSessionCookie(t *testing.T) {
 	}
 	if claims.DisplayName != "User Name" {
 		t.Errorf("expected display name User Name, got %s", claims.DisplayName)
+	}
+}
+
+func Test_Middleware_OIDC_RejectsBearerTokenWithoutSession(t *testing.T) {
+	m := &Middleware{
+		oidcEnabled: true,
+		oauth:       &OAuthHandler{},
+		verifier: &mockTokenVerifier{
+			verifyFn: func(context.Context, string) (VerifiedToken, error) {
+				t.Fatal("expected bearer token not to be verified")
+				return nil, nil
+			},
+		},
+	}
+
+	nextCalled := false
+	next := http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		nextCalled = true
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/assets", nil)
+	req.Header.Set("Authorization", "Bearer signed-access-token")
+	rec := httptest.NewRecorder()
+
+	m.Authenticate(next).ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("expected status 401, got %d", rec.Code)
+	}
+	if nextCalled {
+		t.Fatal("expected next handler not to be called")
 	}
 }

--- a/backend/internal/auth/oauth.go
+++ b/backend/internal/auth/oauth.go
@@ -332,6 +332,15 @@ func (h *OAuthHandler) GetAccessToken(r *http.Request) string {
 	return session.AccessToken
 }
 
+// GetIDToken extracts ID token from session cookie
+func (h *OAuthHandler) GetIDToken(r *http.Request) string {
+	session, err := h.getSessionFromCookie(r)
+	if err != nil || session == nil {
+		return ""
+	}
+	return session.IDToken
+}
+
 func (h *OAuthHandler) setSessionCookie(w http.ResponseWriter, r *http.Request, session *Session) error {
 	data, err := json.Marshal(session)
 	if err != nil {

--- a/backend/internal/auth/oauth_test.go
+++ b/backend/internal/auth/oauth_test.go
@@ -251,6 +251,32 @@ func Test_OAuthHandler_GetAccessToken_ValidSession_ReturnsToken(t *testing.T) {
 	}
 }
 
+func Test_OAuthHandler_GetIDToken_ValidSession_ReturnsToken(t *testing.T) {
+	handler := &OAuthHandler{
+		disabled: false,
+		secret:   make([]byte, 32),
+	}
+
+	session := Session{
+		IDToken:   "my-id-token",
+		ExpiresAt: time.Now().Add(1 * time.Hour),
+	}
+	data, _ := json.Marshal(session)
+	encoded := base64.StdEncoding.EncodeToString(data)
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.AddCookie(&http.Cookie{
+		Name:  sessionCookieName,
+		Value: encoded,
+	})
+
+	token := handler.GetIDToken(req)
+
+	if token != "my-id-token" {
+		t.Errorf("expected 'my-id-token', got '%s'", token)
+	}
+}
+
 func Test_OAuthHandler_setSessionCookie_EncodesSession(t *testing.T) {
 	handler := &OAuthHandler{
 		disabled: false,

--- a/backend/internal/auth/oidc_keycloak_integration_test.go
+++ b/backend/internal/auth/oidc_keycloak_integration_test.go
@@ -1,0 +1,324 @@
+package auth
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/testcontainers/testcontainers-go"
+	"github.com/testcontainers/testcontainers-go/wait"
+)
+
+type keycloakProvider struct {
+	container    testcontainers.Container
+	issuerURL    string
+	clientID     string
+	clientSecret string
+	username     string
+	password     string
+}
+
+type keycloakTokenResponse struct {
+	AccessToken string `json:"access_token"`
+	IDToken     string `json:"id_token"`
+}
+
+var (
+	keycloakOnce     sync.Once
+	keycloakInstance *keycloakProvider
+	keycloakErr      error
+)
+
+func TestMain(m *testing.M) {
+	exitCode := m.Run()
+
+	if keycloakInstance != nil && keycloakInstance.container != nil {
+		_ = keycloakInstance.container.Terminate(context.Background())
+	}
+
+	os.Exit(exitCode)
+}
+
+func Test_Middleware_OIDC_KeycloakSession_UsesIDTokenFromCookie(t *testing.T) {
+	ctx := context.Background()
+	provider, err := getKeycloakProvider()
+	if err != nil {
+		t.Fatalf("failed to start keycloak provider: %v", err)
+	}
+
+	token, err := provider.getUserToken(ctx)
+	if err != nil {
+		t.Fatalf("failed to get user token: %v", err)
+	}
+
+	middleware, err := NewMiddleware(ctx, Config{
+		IssuerURL:   provider.issuerURL,
+		ClientID:    provider.clientID,
+		OIDCEnabled: true,
+	})
+	if err != nil {
+		t.Fatalf("failed to create middleware: %v", err)
+	}
+
+	middleware.SetOAuthHandler(&OAuthHandler{})
+
+	session := Session{
+		AccessToken: "definitely-not-a-valid-jwt",
+		IDToken:     token.IDToken,
+		ExpiresAt:   time.Now().UTC().Add(1 * time.Hour),
+		Email:       "attic@example.com",
+		Name:        "Attic User",
+	}
+	cookieValue, err := encodeSessionCookie(session)
+	if err != nil {
+		t.Fatalf("failed to encode session cookie: %v", err)
+	}
+
+	var claims *Claims
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		claims = GetClaims(r.Context())
+		w.WriteHeader(http.StatusOK)
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/me", nil)
+	req.AddCookie(&http.Cookie{Name: sessionCookieName, Value: cookieValue})
+	rec := httptest.NewRecorder()
+
+	middleware.Authenticate(next).ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d with body: %s", rec.Code, rec.Body.String())
+	}
+	if claims == nil {
+		t.Fatal("expected claims in request context")
+	}
+	if claims.Subject == "" {
+		t.Fatal("expected non-empty subject from ID token")
+	}
+	if claims.Email != "attic@example.com" {
+		t.Fatalf("expected email attic@example.com, got %q", claims.Email)
+	}
+}
+
+func getKeycloakProvider() (*keycloakProvider, error) {
+	keycloakOnce.Do(func() {
+		defer func() {
+			if r := recover(); r != nil {
+				keycloakErr = fmt.Errorf("keycloak container startup panic: %v", r)
+			}
+		}()
+		keycloakInstance, keycloakErr = startKeycloak(context.Background())
+	})
+
+	return keycloakInstance, keycloakErr
+}
+
+func startKeycloak(ctx context.Context) (*keycloakProvider, error) {
+	container, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
+		ContainerRequest: testcontainers.ContainerRequest{
+			Image:        "quay.io/keycloak/keycloak:26.2.0",
+			ExposedPorts: []string{"8080/tcp"},
+			Env: map[string]string{
+				"KC_BOOTSTRAP_ADMIN_USERNAME": "admin",
+				"KC_BOOTSTRAP_ADMIN_PASSWORD": "admin",
+				"KC_HTTP_ENABLED":             "true",
+			},
+			Cmd: []string{"start-dev", "--http-port=8080"},
+			WaitingFor: wait.ForHTTP("/realms/master/.well-known/openid-configuration").
+				WithPort("8080/tcp").
+				WithStatusCodeMatcher(func(status int) bool { return status == http.StatusOK }).
+				WithStartupTimeout(2 * time.Minute),
+		},
+		Started: true,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("start keycloak container: %w", err)
+	}
+
+	host, err := container.Host(ctx)
+	if err != nil {
+		_ = container.Terminate(ctx)
+		return nil, fmt.Errorf("resolve keycloak host: %w", err)
+	}
+	port, err := container.MappedPort(ctx, "8080/tcp")
+	if err != nil {
+		_ = container.Terminate(ctx)
+		return nil, fmt.Errorf("resolve keycloak port: %w", err)
+	}
+
+	baseURL := fmt.Sprintf("http://%s:%s", host, port.Port())
+
+	adminToken, err := getKeycloakAdminToken(ctx, baseURL)
+	if err != nil {
+		_ = container.Terminate(ctx)
+		return nil, err
+	}
+	if err := bootstrapKeycloakRealm(ctx, baseURL, adminToken); err != nil {
+		_ = container.Terminate(ctx)
+		return nil, err
+	}
+
+	return &keycloakProvider{
+		container:    container,
+		issuerURL:    baseURL + "/realms/attic",
+		clientID:     "attic-client",
+		clientSecret: "attic-secret",
+		username:     "attic-user",
+		password:     "attic-password",
+	}, nil
+}
+
+func getKeycloakAdminToken(ctx context.Context, baseURL string) (string, error) {
+	form := url.Values{}
+	form.Set("grant_type", "password")
+	form.Set("client_id", "admin-cli")
+	form.Set("username", "admin")
+	form.Set("password", "admin")
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, baseURL+"/realms/master/protocol/openid-connect/token", strings.NewReader(form.Encode()))
+	if err != nil {
+		return "", fmt.Errorf("create admin token request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("execute admin token request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("admin token request failed with status %d", resp.StatusCode)
+	}
+
+	var payload struct {
+		AccessToken string `json:"access_token"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		return "", fmt.Errorf("decode admin token response: %w", err)
+	}
+	if payload.AccessToken == "" {
+		return "", fmt.Errorf("admin token response missing access_token")
+	}
+
+	return payload.AccessToken, nil
+}
+
+func bootstrapKeycloakRealm(ctx context.Context, baseURL, adminToken string) error {
+	realmPayload := map[string]any{
+		"realm":   "attic",
+		"enabled": true,
+		"clients": []map[string]any{
+			{
+				"clientId":                  "attic-client",
+				"name":                      "Attic",
+				"enabled":                   true,
+				"protocol":                  "openid-connect",
+				"publicClient":              false,
+				"secret":                    "attic-secret",
+				"directAccessGrantsEnabled": true,
+				"standardFlowEnabled":       true,
+				"serviceAccountsEnabled":    true,
+				"redirectUris":              []string{"http://app.localtest.me:8080/auth/oidc/callback"},
+				"webOrigins":                []string{"*"},
+				"defaultClientScopes":       []string{"profile", "email"},
+				"fullScopeAllowed":          true,
+			},
+		},
+		"users": []map[string]any{
+			{
+				"username":      "attic-user",
+				"enabled":       true,
+				"emailVerified": true,
+				"email":         "attic@example.com",
+				"firstName":     "Attic",
+				"lastName":      "User",
+				"credentials": []map[string]any{
+					{
+						"type":      "password",
+						"value":     "attic-password",
+						"temporary": false,
+					},
+				},
+			},
+		},
+	}
+
+	body, err := json.Marshal(realmPayload)
+	if err != nil {
+		return fmt.Errorf("marshal realm payload: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, baseURL+"/admin/realms", bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("create realm bootstrap request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+adminToken)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("execute realm bootstrap request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusCreated && resp.StatusCode != http.StatusConflict {
+		return fmt.Errorf("realm bootstrap failed with status %d", resp.StatusCode)
+	}
+
+	return nil
+}
+
+func (p *keycloakProvider) getUserToken(ctx context.Context) (*keycloakTokenResponse, error) {
+	form := url.Values{}
+	form.Set("grant_type", "password")
+	form.Set("client_id", p.clientID)
+	form.Set("client_secret", p.clientSecret)
+	form.Set("username", p.username)
+	form.Set("password", p.password)
+	form.Set("scope", "openid profile email")
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, p.issuerURL+"/protocol/openid-connect/token", strings.NewReader(form.Encode()))
+	if err != nil {
+		return nil, fmt.Errorf("create user token request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("execute user token request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("user token request failed with status %d", resp.StatusCode)
+	}
+
+	var payload keycloakTokenResponse
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		return nil, fmt.Errorf("decode user token response: %w", err)
+	}
+	if payload.IDToken == "" {
+		return nil, fmt.Errorf("user token response missing id_token")
+	}
+
+	return &payload, nil
+}
+
+func encodeSessionCookie(session Session) (string, error) {
+	data, err := json.Marshal(session)
+	if err != nil {
+		return "", err
+	}
+	return base64.StdEncoding.EncodeToString(data), nil
+}


### PR DESCRIPTION
## Summary

  Fixes #20.

  Attic previously passed the OAuth access token to the OIDC ID-token verifier when authenticating requests from a browser session.

  This fails with providers such as Authelia that issue opaque access tokens:

  ```text
  oidc: malformed jwt: compact JWS format must have three parts
```

  ## Changes

  - Use the ID token stored in the OIDC session cookie for authentication.
  - Validate the ID token’s signature, issuer, expiry, and client ID.
  - Stop treating OAuth access tokens as ID tokens.
  - Use cookie-based authentication consistently across the API.
  - Update the OpenAPI specification to document session-cookie authentication instead of Keycloak bearer JWTs.
  - Add unit and integration coverage for sessions containing an opaque access token and a valid ID token.

  ## Provider compatibility

  The implementation is not tied to Keycloak or Authelia. Keycloak is used only as the integration-test OIDC provider.

  Any standards-compliant OIDC provider can be used, regardless of whether its access tokens are opaque or JWTs.

  ## Further work - Bearer and mobile authentication

With the plans of building a mobile application this brings to light an issue with mobile authentication

 Direct Authorization: Bearer access-token authentication is intentionally not supported by this change.

  Attic currently authenticates API requests through its OIDC session cookie. Bearer authentication will be designed separately when mobile application support is introduced, using Attic-issued session
  tokens rather than relying on provider-specific access-token formats.

  ## Verification

  - go test ./... -count=1
  - go vet ./...
  - git diff --check

  The Keycloak integration test verifies that authentication succeeds when the session contains an invalid/opaque access token alongside a valid ID token.