### PR TITLE
fix: button to toggle light and dark mode is now always visible

### DIFF
--- a/frontend/app/app.vue
+++ b/frontend/app/app.vue
@@ -266,6 +266,7 @@ const sidebarOpen = ref(false)
                   </div>
                 </template>
               </UDropdownMenu>
+              <UColorModeButton />
             </div>
           </div>
         </aside>


### PR DESCRIPTION
Button to toggle light and dark mode is now always visible in the interface