### PR TITLE
fix(api): update asset with no custom attributes

### DIFF
--- a/backend/internal/repository/asset.go
+++ b/backend/internal/repository/asset.go
@@ -286,6 +286,9 @@ func (r *AssetRepository) Update(ctx context.Context, a *domain.Asset) error {
 		WHERE id = $1 AND deleted_at IS NULL
 		RETURNING updated_at
 	`
+	if a.Attributes == nil {
+		a.Attributes = []byte("{}")
+	}
 	return r.pool.QueryRow(ctx, query,
 		a.ID, a.CategoryID, a.LocationID, a.ConditionID, a.CollectionID,
 		a.Name, a.Description, a.Quantity, a.Attributes, a.PurchaseAt, a.PurchasePrice, a.PurchaseNote, a.Notes,

--- a/backend/internal/repository/asset_test.go
+++ b/backend/internal/repository/asset_test.go
@@ -385,6 +385,42 @@ func Test_AssetRepository_Update_Success(t *testing.T) {
 	}
 }
 
+func Test_AssetRepository_Update_WithNilAttributes_StoresEmptyObject(t *testing.T) {
+	ctx := context.Background()
+	if err := testDB.TruncateAll(ctx); err != nil {
+		t.Fatalf("failed to truncate: %v", err)
+	}
+
+	fixtures := testutil.NewFixtures(testDB.Pool)
+	org, _ := fixtures.CreateOrganization(ctx, "Test Org")
+	cat, _ := fixtures.CreateCategory(ctx, org.ID, "Electronics", nil)
+
+	repo := NewAssetRepository(testDB.Pool)
+	asset := &domain.Asset{
+		OrganizationID: org.ID,
+		CategoryID:     cat.ID,
+		Name:           "Test Asset",
+		Quantity:       1,
+	}
+	if err := repo.Create(ctx, asset); err != nil {
+		t.Fatalf("failed to create asset: %v", err)
+	}
+
+	asset.Attributes = nil
+	asset.Name = "Updated Asset"
+	if err := repo.Update(ctx, asset); err != nil {
+		t.Fatalf("failed to update asset without attributes: %v", err)
+	}
+
+	fetched, err := repo.GetByID(ctx, asset.ID)
+	if err != nil {
+		t.Fatalf("failed to get updated asset: %v", err)
+	}
+	if string(fetched.Attributes) != "{}" {
+		t.Errorf("expected empty attributes object, got %s", fetched.Attributes)
+	}
+}
+
 func Test_AssetRepository_Delete_SoftDelete(t *testing.T) {
 	ctx := context.Background()
 	if err := testDB.TruncateAll(ctx); err != nil {


### PR DESCRIPTION
# Summary
Implemented the fix for [issue #29](https://github.com/lmmendes/attic/issues/29).

  - Nil asset attributes now become {} before database updates in backend/internal/repository/
    asset.go:289.
  - Added a PostgreSQL regression test in backend/internal/repository/asset_test.go:388.
  - Full backend suite passes: go test ./...
  - git diff --check passes.