### PR TITLE
fix(storage): initialize Docker volume ownership before dropping privileges

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -31,6 +31,8 @@ dockers_v2:
   - ids:
       - attic
     dockerfile: Dockerfile.goreleaser
+    extra_files:
+      - backend/docker-entrypoint.sh
     images:
       - ghcr.io/lmmendes/attic
       - lmmendes/attic

--- a/Dockerfile.goreleaser
+++ b/Dockerfile.goreleaser
@@ -5,14 +5,16 @@ ARG TARGETPLATFORM
 WORKDIR /app
 
 # Install ca-certificates for HTTPS and tzdata for timezone support
-RUN apk add --no-cache ca-certificates tzdata
+RUN apk add --no-cache ca-certificates su-exec tzdata
 
 # Copy pre-built binary from GoReleaser (platform-specific path)
 COPY ${TARGETPLATFORM}/attic /app/attic
+COPY --chmod=755 backend/docker-entrypoint.sh /app/docker-entrypoint.sh
 
 # Create non-root user
-RUN adduser -D -g '' appuser
-USER appuser
+RUN adduser -D -g '' appuser \
+    && mkdir -p /data/uploads \
+    && chown appuser:appuser /data/uploads
 
 # Expose port
 EXPOSE 8080
@@ -22,4 +24,5 @@ HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
     CMD wget --no-verbose --tries=1 --spider http://localhost:8080/health || exit 1
 
 # Run the binary
-ENTRYPOINT ["/app/attic"]
+ENTRYPOINT ["/app/docker-entrypoint.sh"]
+CMD ["/app/attic"]

--- a/Dockerfile.snapshot
+++ b/Dockerfile.snapshot
@@ -38,16 +38,19 @@ FROM alpine:3.20
 
 WORKDIR /app
 
-RUN apk add --no-cache ca-certificates tzdata
+RUN apk add --no-cache ca-certificates su-exec tzdata
 
 COPY --from=backend-builder /app/attic /app/attic
+COPY --chmod=755 backend/docker-entrypoint.sh /app/docker-entrypoint.sh
 
-RUN adduser -D -g '' appuser
-USER appuser
+RUN adduser -D -g '' appuser \
+    && mkdir -p /data/uploads \
+    && chown appuser:appuser /data/uploads
 
 EXPOSE 8080
 
 HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
     CMD wget --no-verbose --tries=1 --spider http://localhost:8080/health || exit 1
 
-ENTRYPOINT ["/app/attic"]
+ENTRYPOINT ["/app/docker-entrypoint.sh"]
+CMD ["/app/attic"]

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -14,22 +14,24 @@ RUN go mod download
 COPY . .
 
 # Build the binary
-RUN CGO_ENABLED=0 GOOS=linux go build -ldflags="-w -s" -o /app/server ./cmd/server
+RUN CGO_ENABLED=0 GOOS=linux go build -ldflags="-w -s" -o /app/attic ./cmd/server
 
 # Runtime stage
 FROM alpine:3.20
 
 WORKDIR /app
 
-# Install ca-certificates for HTTPS
-RUN apk add --no-cache ca-certificates tzdata
+# Install runtime dependencies
+RUN apk add --no-cache ca-certificates su-exec tzdata
 
 # Copy binary from builder
-COPY --from=builder /app/server /app/server
+COPY --from=builder /app/attic /app/attic
+COPY --chmod=755 docker-entrypoint.sh /app/docker-entrypoint.sh
 
 # Create non-root user
-RUN adduser -D -g '' appuser
-USER appuser
+RUN adduser -D -g '' appuser \
+    && mkdir -p /data/uploads \
+    && chown appuser:appuser /data/uploads
 
 # Expose port
 EXPOSE 8080
@@ -39,4 +41,5 @@ HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
     CMD wget --no-verbose --tries=1 --spider http://localhost:8080/health || exit 1
 
 # Run the binary
-ENTRYPOINT ["/app/server"]
+ENTRYPOINT ["/app/docker-entrypoint.sh"]
+CMD ["/app/attic"]

--- a/backend/docker-entrypoint.sh
+++ b/backend/docker-entrypoint.sh
@@ -1,0 +1,34 @@
+#!/bin/sh
+set -eu
+
+storage_path=${ATTIC_LOCAL_STORAGE_PATH:-/data/uploads}
+run_uid=$(id -u appuser)
+run_gid=$(id -g appuser)
+
+if [ -z "${ATTIC_S3_ACCESS_KEY:-}" ] || [ -z "${ATTIC_S3_SECRET_KEY:-}" ]; then
+	if [ -n "${ATTIC_PUID:-}" ] || [ -n "${ATTIC_PGID:-}" ]; then
+		if [ -z "${ATTIC_PUID:-}" ] || [ -z "${ATTIC_PGID:-}" ]; then
+			echo "ATTIC_PUID and ATTIC_PGID must be set together" >&2
+			exit 1
+		fi
+
+		case "${ATTIC_PUID}:${ATTIC_PGID}" in
+			*[!0-9:]* | *:*:*)
+				echo "ATTIC_PUID and ATTIC_PGID must be non-negative integers" >&2
+				exit 1
+				;;
+		esac
+
+		run_uid=${ATTIC_PUID}
+		run_gid=${ATTIC_PGID}
+	fi
+
+	mkdir -p "$storage_path"
+	chown "$run_uid:$run_gid" "$storage_path"
+fi
+
+case "${1:-}" in
+	-*) set -- /app/attic "$@" ;;
+esac
+
+exec su-exec "$run_uid:$run_gid" "$@"

--- a/backend/internal/storage/local.go
+++ b/backend/internal/storage/local.go
@@ -138,5 +138,11 @@ func (s *LocalStorage) chown(path string) error {
 	if s.puid == nil || s.pgid == nil {
 		return nil
 	}
+	// Container startup runs the process as the requested user/group. Files it
+	// creates already have the requested ownership, and a non-root process is
+	// not allowed to call chown even when the ownership would be unchanged.
+	if os.Geteuid() == *s.puid && os.Getegid() == *s.pgid {
+		return nil
+	}
 	return os.Chown(path, *s.puid, *s.pgid)
 }


### PR DESCRIPTION
Fixes issue #38 

## What was happening

Attachment uploads returned a 503 storage not configured error when local storage was used with `ATTIC_PUID` and `ATTIC_PGID`.

The container runs as an unprivileged user but the application tried to change the ownership of the upload directory during startup. Because that user cannot run `chown`, local storage failed to initialize and attachments were silently disabled.

## Changes

- Creates the local storage directory when needed.
- Sets its ownership using the configured `PUID` and `PGID`.
- Drops privileges before starting Attic.
- Keeps S3 installations unchanged.
- Validates that `PUID` and `PGID` are valid and provided together.

The local storage implementation now also skips unnecessary chown calls when the process is already running as the requested user and group.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Docker images now support running with configurable user and group IDs.
  * Container startup automatically prepares the local upload directory with appropriate permissions.
  * Docker-based deployments can pass command-line options directly when starting the application.

* **Bug Fixes**
  * Improved local storage handling to avoid unnecessary ownership changes when permissions are already correct.
  * Improved container startup behavior for deployments using local storage without object-storage credentials.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->