### PR TITLE
fix(docker)!: run container images as non-root by default

### DIFF
--- a/Dockerfile.goreleaser
+++ b/Dockerfile.goreleaser
@@ -11,10 +11,11 @@ RUN apk add --no-cache ca-certificates su-exec tzdata
 COPY ${TARGETPLATFORM}/attic /app/attic
 COPY --chmod=755 backend/docker-entrypoint.sh /app/docker-entrypoint.sh
 
-# Create non-root user
-RUN adduser -D -g '' appuser \
+# Create the numeric non-root user Kubernetes verifies for runAsNonRoot.
+RUN addgroup -g 1000 appgroup \
+    && adduser -D -u 1000 -G appgroup appuser \
     && mkdir -p /data/uploads \
-    && chown appuser:appuser /data/uploads
+    && chown appuser:appgroup /data/uploads
 
 # Expose port
 EXPOSE 8080
@@ -22,6 +23,9 @@ EXPOSE 8080
 # Health check
 HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
     CMD wget --no-verbose --tries=1 --spider http://localhost:8080/health || exit 1
+
+# Use a numeric UID/GID so runtimes can enforce runAsNonRoot before startup.
+USER 1000:1000
 
 # Run the binary
 ENTRYPOINT ["/app/docker-entrypoint.sh"]

--- a/Dockerfile.snapshot
+++ b/Dockerfile.snapshot
@@ -43,14 +43,17 @@ RUN apk add --no-cache ca-certificates su-exec tzdata
 COPY --from=backend-builder /app/attic /app/attic
 COPY --chmod=755 backend/docker-entrypoint.sh /app/docker-entrypoint.sh
 
-RUN adduser -D -g '' appuser \
+RUN addgroup -g 1000 appgroup \
+    && adduser -D -u 1000 -G appgroup appuser \
     && mkdir -p /data/uploads \
-    && chown appuser:appuser /data/uploads
+    && chown appuser:appgroup /data/uploads
 
 EXPOSE 8080
 
 HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
     CMD wget --no-verbose --tries=1 --spider http://localhost:8080/health || exit 1
+
+USER 1000:1000
 
 ENTRYPOINT ["/app/docker-entrypoint.sh"]
 CMD ["/app/attic"]

--- a/README.md
+++ b/README.md
@@ -9,16 +9,16 @@ It mirrors the way your real-world spaces are organized with hierarchical locati
 ## Key Features
 
 **Asset Management**
-- Full CRUD with custom attributes per category (strings, numbers, booleans, dates, dropdowns)
+- Full CRUD with custom attributes per category (strings, long text, numbers, booleans, and dates)
 - Hierarchical categories and locations that mirror real-world spaces
 - Condition tracking (new, used, damaged, or custom states)
-- Warranty expiration monitoring with alerts
+- Warranty expiration monitoring on the dashboard
 - File attachments for invoices, manuals, and photos
-- Collections for grouping related assets (e.g. board game + expansions)
+- Purchase dates, prices, and notes with dashboard value summaries
 
 **Search & Discovery**
-- Full-text search across names, descriptions, tags, and custom fields
-- Filter by category, location, condition, tags, and typed attribute values
+- Full-text search across asset names and descriptions
+- Filter by category, location, and condition
 
 **Smart Integrations**
 - Automated imports from Google Books, TMDB (movies), and BoardGameGeek
@@ -28,8 +28,9 @@ It mirrors the way your real-world spaces are organized with hierarchical locati
 **Self-Hosted & Secure**
 - Docker-based deployment with complete data ownership
 - OIDC/SSO authentication (Keycloak compatible)
+- Local user and role management
 - REST API with Swagger documentation
-- S3-compatible storage for attachments
+- Local or S3-compatible storage for attachments
 - Dark mode with mobile-responsive UI
 
 ## Quick Start

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -28,10 +28,11 @@ RUN apk add --no-cache ca-certificates su-exec tzdata
 COPY --from=builder /app/attic /app/attic
 COPY --chmod=755 docker-entrypoint.sh /app/docker-entrypoint.sh
 
-# Create non-root user
-RUN adduser -D -g '' appuser \
+# Create the numeric non-root user Kubernetes verifies for runAsNonRoot.
+RUN addgroup -g 1000 appgroup \
+    && adduser -D -u 1000 -G appgroup appuser \
     && mkdir -p /data/uploads \
-    && chown appuser:appuser /data/uploads
+    && chown appuser:appgroup /data/uploads
 
 # Expose port
 EXPOSE 8080
@@ -39,6 +40,9 @@ EXPOSE 8080
 # Health check
 HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
     CMD wget --no-verbose --tries=1 --spider http://localhost:8080/health || exit 1
+
+# Use a numeric UID/GID so runtimes can enforce runAsNonRoot before startup.
+USER 1000:1000
 
 # Run the binary
 ENTRYPOINT ["/app/docker-entrypoint.sh"]

--- a/backend/docker-entrypoint.sh
+++ b/backend/docker-entrypoint.sh
@@ -2,10 +2,16 @@
 set -eu
 
 storage_path=${ATTIC_LOCAL_STORAGE_PATH:-/data/uploads}
-run_uid=$(id -u appuser)
-run_gid=$(id -g appuser)
 current_uid=$(id -u)
 current_gid=$(id -g)
+
+# Honor the runtime identity unless root needs to drop privileges.
+run_uid=$current_uid
+run_gid=$current_gid
+if [ "$current_uid" -eq 0 ]; then
+	run_uid=$(id -u appuser)
+	run_gid=$(id -g appuser)
+fi
 
 if [ -z "${ATTIC_S3_ACCESS_KEY:-}" ] || [ -z "${ATTIC_S3_SECRET_KEY:-}" ]; then
 	if [ -n "${ATTIC_PUID:-}" ] || [ -n "${ATTIC_PGID:-}" ]; then

--- a/backend/docker-entrypoint.sh
+++ b/backend/docker-entrypoint.sh
@@ -4,6 +4,8 @@ set -eu
 storage_path=${ATTIC_LOCAL_STORAGE_PATH:-/data/uploads}
 run_uid=$(id -u appuser)
 run_gid=$(id -g appuser)
+current_uid=$(id -u)
+current_gid=$(id -g)
 
 if [ -z "${ATTIC_S3_ACCESS_KEY:-}" ] || [ -z "${ATTIC_S3_SECRET_KEY:-}" ]; then
 	if [ -n "${ATTIC_PUID:-}" ] || [ -n "${ATTIC_PGID:-}" ]; then
@@ -24,11 +26,20 @@ if [ -z "${ATTIC_S3_ACCESS_KEY:-}" ] || [ -z "${ATTIC_S3_SECRET_KEY:-}" ]; then
 	fi
 
 	mkdir -p "$storage_path"
-	chown "$run_uid:$run_gid" "$storage_path"
+	if [ "$current_uid" -eq 0 ]; then
+		chown "$run_uid:$run_gid" "$storage_path"
+	elif [ "$run_uid" -ne "$current_uid" ] || [ "$run_gid" -ne "$current_gid" ]; then
+		echo "ATTIC_PUID/ATTIC_PGID must match the container UID/GID when running as non-root (current: ${current_uid}:${current_gid})" >&2
+		exit 1
+	fi
 fi
 
 case "${1:-}" in
 	-*) set -- /app/attic "$@" ;;
 esac
 
-exec su-exec "$run_uid:$run_gid" "$@"
+if [ "$current_uid" -eq 0 ]; then
+	exec su-exec "$run_uid:$run_gid" "$@"
+fi
+
+exec "$@"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,9 @@ version: "3.8"
 services:
   attic:
     image: ghcr.io/lmmendes/attic:latest
+    # Start the entrypoint as root so it can apply optional PUID/PGID ownership;
+    # the entrypoint drops privileges before starting attic.
+    user: "0:0"
     ports:
       - "8080:8080"
     environment:


### PR DESCRIPTION
## What changed

  Container images now default to numeric UID/GID `1000:1000`, allowing Kubernetes to enforce non-
  root startup with all capabilities dropped.

  When started as non-root, the entrypoint preserves the runtime UID/GID and skips ownership changes
  and privilege switching. Custom identities supplied through Docker or Kubernetes are supported.

  Root startup remains available for preparing local-storage ownership before dropping privileges.

  ## Breaking change

  Existing deployments that rely on root startup to prepare storage permissions, or set custom
  `ATTIC_PUID`/`ATTIC_PGID`, may require configuration changes before upgrading.

  Pulling the new image does not update existing Compose files.

  ## Migration instructions

  ### Preserve existing Docker ownership setup

  Add this setting to your existing attic Compose service:

      services:
        attic:
          user: "0:0"

  Keep your existing `ATTIC_PUID` and `ATTIC_PGID` settings. For standalone Docker, add `--user 0:0`.

  The entrypoint prepares ownership of the local-storage base directory, then starts attic as the
  configured UID/GID, or `1000:1000` when unset. Existing files are not recursively re-owned.

  ### Start directly as non-root

  Use the default `1000:1000`, or choose an identity with Compose `user`, Docker `--user`, or
  Kubernetes `runAsUser` and `runAsGroup`.

  Leave `ATTIC_PUID` and `ATTIC_PGID` unset. If explicitly configured for local storage, both must
  match the runtime UID/GID.

  Ensure mounted storage and existing uploads are accessible to the selected identity. Non-root
  startup does not repair ownership. In Kubernetes, configure `fsGroup` where supported by the
  volume/CSI driver, or provision permissions separately.

  Deployments already using writable storage with UID/GID `1000:1000` generally require no changes.

  ## Validation

  - Verified startup and writes as `1000:1000`, `2000:2000`, and `1000:2000` with all capabilities
  dropped and privilege escalation disabled.
  - Verified explicit UID/GID matching and mismatch rejection.
  - Verified root startup still drops privileges.
  - ShellCheck passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved container startup and storage access by applying consistent user and group permissions.
  * Containers now better support deployments using custom process IDs while safely handling privilege changes.

* **Documentation**
  * Updated the feature overview to reflect current capabilities, including typed custom attributes, warranty monitoring, purchase summaries, local user and role management, and local or S3-compatible attachment storage.
  * Revised search and filtering descriptions to match the available coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->