### PR TITLE
feat(google-books): avoid unauthenticated API quota limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,10 @@ Attic mirrors the way a home is organized with nested locations such as rooms, s
 - Metadata and cover images populated automatically
 - Plugin system for adding new import sources
 
+Google Books works without credentials, but Google may apply a low shared quota to unauthenticated
+requests. Set `ATTIC_GOOGLE_BOOKS_API_KEY` to a Google Books API key for reliable imports in a
+self-hosted or shared deployment. The key is sent only to Google Books API requests.
+
 **Self-Hosted & Secure**
 - Docker-based deployment with complete data ownership
 - Local password authentication and OIDC/SSO (Keycloak compatible)

--- a/backend/internal/plugin/googlebooks/googlebooks.go
+++ b/backend/internal/plugin/googlebooks/googlebooks.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"os"
 	"strings"
 	"time"
 
@@ -13,10 +14,21 @@ import (
 )
 
 const (
-	PluginID    = "google_books"
-	baseURL     = "https://www.googleapis.com/books/v1/volumes"
-	defaultLimit = 10
+	PluginID                = "google_books"
+	baseURL                 = "https://www.googleapis.com/books/v1/volumes"
+	defaultLimit            = 10
+	googleBooksAPIKeyEnvVar = "ATTIC_GOOGLE_BOOKS_API_KEY"
 )
+
+// APIKey can be set at build time via ldflags. The environment variable takes precedence.
+var APIKey = ""
+
+func getAPIKey() string {
+	if key := os.Getenv(googleBooksAPIKeyEnvVar); key != "" {
+		return key
+	}
+	return APIKey
+}
 
 // Plugin implements the Google Books import plugin
 type Plugin struct {
@@ -114,6 +126,9 @@ func (p *Plugin) Search(ctx context.Context, field, query string, limit int) ([]
 	params.Set("q", q)
 	params.Set("maxResults", fmt.Sprintf("%d", limit))
 	params.Set("printType", "books")
+	if apiKey := getAPIKey(); apiKey != "" {
+		params.Set("key", apiKey)
+	}
 	u.RawQuery = params.Encode()
 
 	// Make request
@@ -177,6 +192,9 @@ func (p *Plugin) Search(ctx context.Context, field, query string, limit int) ([]
 // Fetch retrieves full book data by external ID
 func (p *Plugin) Fetch(ctx context.Context, externalID string) (*domain.ImportData, error) {
 	u := fmt.Sprintf("%s/%s", baseURL, url.PathEscape(externalID))
+	if apiKey := getAPIKey(); apiKey != "" {
+		u += "?key=" + url.QueryEscape(apiKey)
+	}
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
 	if err != nil {


### PR DESCRIPTION
## Overview

  Google Books imports could fail with an upstream `429` response because Attic sent unauthenticated
  requests. This change adds optional Google Books API key support so self-hosted installations can
  use their own quota.

  ## Changes

  - Added support for `ATTIC_GOOGLE_BOOKS_API_KEY`.
  - Included the API key in Google Books search requests.
  - Included the API key when fetching imported book details.
  - Added the variable to `docker-compose.yml`.
  - Documented Google Books API key setup in the README.
  - Added development setup guidance to `docker-compose.dev.yml`.

  The key remains optional, so existing installations continue to work until Google’s unauthenticated
  quota is exhausted.

  ## Configuration

```env
  ATTIC_GOOGLE_BOOKS_API_KEY=your-google-books-api-key
```

  The key must be created in Google Cloud Console with the Books API enabled. See https://getattic.dev/guides/import-plugins/#google-books for information about the configuration.

  ## Problem addressed

  Before this change:

  Google Books API → 429 Too Many Requests → Attic 502 Bad Gateway

  After configuring an API key, requests use the installation’s Google Cloud quota.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Google Books requests can now use an API key configured through the environment or build settings.
  - API key guidance, request scope, and unauthenticated quota limitations are documented.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->