### PR TITLE
feat(plugins): report configuration and initialize categories at startup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -68,6 +68,14 @@ KEYCLOAK_DB=keycloak
 # ATTIC_SESSION_SECRET=change-me-in-production-32chars!
 
 # --------------------------------------
+# Import Plugin API Keys
+# --------------------------------------
+# Google Books can work without a key, but a key avoids the shared anonymous quota
+# ATTIC_GOOGLE_BOOKS_API_KEY=your-google-books-api-key
+# ATTIC_TMDB_API_KEY=your-tmdb-api-key
+# ATTIC_BGG_API_KEY=your-boardgamegeek-api-key
+
+# --------------------------------------
 # Local Storage Configuration
 # --------------------------------------
 # Used when S3 credentials are not configured

--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -196,23 +196,18 @@ func main() {
 
 	// Initialize plugin registry
 	pluginRegistry := plugin.NewRegistry()
-	if err := pluginRegistry.Register(googlebooks.New()); err != nil {
-		slog.Error("failed to register Google Books plugin", "error", err)
-	}
-	if err := pluginRegistry.Register(tmdb.NewMoviesPlugin()); err != nil {
-		slog.Error("failed to register TMDB Movies plugin", "error", err)
-	}
-	if err := pluginRegistry.Register(tmdb.NewSeriesPlugin()); err != nil {
-		slog.Error("failed to register TMDB Series plugin", "error", err)
-	}
-	if err := pluginRegistry.Register(bgg.New()); err != nil {
-		slog.Error("failed to register BGG plugin", "error", err)
-	}
+	registerImportPlugin(pluginRegistry, googlebooks.New(), "ATTIC_GOOGLE_BOOKS_API_KEY")
+	registerImportPlugin(pluginRegistry, tmdb.NewMoviesPlugin(), "ATTIC_TMDB_API_KEY")
+	registerImportPlugin(pluginRegistry, tmdb.NewSeriesPlugin(), "ATTIC_TMDB_API_KEY")
+	registerImportPlugin(pluginRegistry, bgg.New(), "ATTIC_BGG_API_KEY")
 	slog.Info("registered plugins", "count", len(pluginRegistry.List()))
 
 	// Initialize handlers
 	h := handler.New(db, repos, fileStorage, defaultOrgID)
 	pluginHandler := handler.NewPluginHandler(pluginRegistry, repos, fileStorage, defaultOrgID)
+	if err := pluginHandler.InitializeEnabledPluginCategories(ctx); err != nil {
+		slog.Warn("one or more plugin categories could not be initialized", "error", err)
+	}
 	authHandler := handler.NewAuthHandler(userRepo, sessionManager, cfg.PasswordMinLength, cfg.OIDCEnabled, cfg.OIDCAutoRedirect)
 	if oauthHandler != nil {
 		authHandler.SetOAuthHandler(oauthHandler)
@@ -434,6 +429,23 @@ func main() {
 	}
 
 	slog.Info("server stopped")
+}
+
+func registerImportPlugin(registry *plugin.Registry, importPlugin domain.ImportPlugin, apiKeyEnv string) {
+	if err := registry.Register(importPlugin); err != nil {
+		slog.Error("failed to register import plugin",
+			"plugin_id", importPlugin.ID(),
+			"plugin_name", importPlugin.Name(),
+			"error", err)
+		return
+	}
+
+	slog.Info("registered import plugin",
+		"plugin_id", importPlugin.ID(),
+		"plugin_name", importPlugin.Name(),
+		"enabled", importPlugin.Enabled(),
+		"api_key_environment_variable", apiKeyEnv,
+		"api_key_set", strings.TrimSpace(os.Getenv(apiKeyEnv)) != "")
 }
 
 // bootstrapAdmin creates the initial admin user if no users exist

--- a/backend/cmd/server/main_test.go
+++ b/backend/cmd/server/main_test.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"log/slog"
+	"strings"
+	"testing"
+
+	"github.com/lmmendes/attic/internal/domain"
+	"github.com/lmmendes/attic/internal/plugin"
+)
+
+type startupTestPlugin struct{}
+
+func (startupTestPlugin) ID() string                           { return "test_plugin" }
+func (startupTestPlugin) Name() string                         { return "Test Plugin" }
+func (startupTestPlugin) Description() string                  { return "Test plugin" }
+func (startupTestPlugin) Enabled() bool                        { return true }
+func (startupTestPlugin) DisabledReason() string               { return "" }
+func (startupTestPlugin) CategoryName() string                 { return "Test Category" }
+func (startupTestPlugin) CategoryDescription() string          { return "Test category" }
+func (startupTestPlugin) Attributes() []domain.PluginAttribute { return nil }
+func (startupTestPlugin) SearchFields() []domain.SearchField   { return nil }
+func (startupTestPlugin) Search(context.Context, string, string, int) ([]domain.SearchResult, error) {
+	return nil, nil
+}
+func (startupTestPlugin) Fetch(context.Context, string) (*domain.ImportData, error) {
+	return nil, nil
+}
+
+func TestRegisterImportPluginLogsAPIKeyPresenceWithoutValue(t *testing.T) {
+	const apiKeyEnvironmentVariable = "ATTIC_TEST_API_KEY"
+	const apiKey = "secret-test-api-key"
+	t.Setenv(apiKeyEnvironmentVariable, apiKey)
+
+	var output bytes.Buffer
+	previousLogger := slog.Default()
+	slog.SetDefault(slog.New(slog.NewJSONHandler(&output, nil)))
+	t.Cleanup(func() { slog.SetDefault(previousLogger) })
+
+	registry := plugin.NewRegistry()
+	registerImportPlugin(registry, startupTestPlugin{}, apiKeyEnvironmentVariable)
+
+	logOutput := output.String()
+	if !strings.Contains(logOutput, `"api_key_environment_variable":"ATTIC_TEST_API_KEY"`) {
+		t.Fatalf("expected API key environment variable in log, got %s", logOutput)
+	}
+	if !strings.Contains(logOutput, `"api_key_set":true`) {
+		t.Fatalf("expected configured API key status in log, got %s", logOutput)
+	}
+	if strings.Contains(logOutput, apiKey) {
+		t.Fatal("API key value must not be written to logs")
+	}
+}

--- a/backend/internal/handler/plugin.go
+++ b/backend/internal/handler/plugin.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -27,6 +28,18 @@ type PluginHandler struct {
 	orgID    uuid.UUID
 }
 
+type pluginCategoryRepository interface {
+	GetByPluginID(context.Context, uuid.UUID, string) (*domain.Category, error)
+	GetByIDWithAttributes(context.Context, uuid.UUID) (*domain.Category, error)
+	Create(context.Context, *domain.Category) error
+	SetAttributes(context.Context, uuid.UUID, []domain.CategoryAttributeAssignment) error
+}
+
+type pluginAttributeRepository interface {
+	GetByKey(context.Context, uuid.UUID, string) (*domain.Attribute, error)
+	Create(context.Context, *domain.Attribute) error
+}
+
 // NewPluginHandler creates a new PluginHandler
 func NewPluginHandler(registry *plugin.Registry, repos *Repositories, storage FileStorage, defaultOrgID uuid.UUID) *PluginHandler {
 	return &PluginHandler{
@@ -35,6 +48,37 @@ func NewPluginHandler(registry *plugin.Registry, repos *Repositories, storage Fi
 		storage:  storage,
 		orgID:    defaultOrgID,
 	}
+}
+
+// InitializeEnabledPluginCategories creates the category schema for every usable
+// import plugin before the server begins accepting requests.
+func (h *PluginHandler) InitializeEnabledPluginCategories(ctx context.Context) error {
+	var initializationErrors []error
+
+	for _, p := range h.registry.List() {
+		if !p.Enabled() {
+			continue
+		}
+
+		category, created, err := h.ensurePluginCategory(ctx, p)
+		if err != nil {
+			slog.Error("failed to initialize plugin category",
+				"plugin_id", p.ID(),
+				"plugin_name", p.Name(),
+				"error", err)
+			initializationErrors = append(initializationErrors, fmt.Errorf("%s: %w", p.ID(), err))
+			continue
+		}
+
+		slog.Info("initialized plugin category",
+			"plugin_id", p.ID(),
+			"plugin_name", p.Name(),
+			"category_id", category.ID,
+			"category_name", category.Name,
+			"created", created)
+	}
+
+	return errors.Join(initializationErrors...)
 }
 
 // PluginListResponse represents the response for listing plugins
@@ -275,7 +319,7 @@ func (h *PluginHandler) Import(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Ensure category exists for this plugin
-	cat, err := h.ensurePluginCategory(r, p)
+	cat, _, err := h.ensurePluginCategory(r.Context(), p)
 	if err != nil {
 		slog.Error("failed to ensure plugin category",
 			"plugin_id", pluginID,
@@ -338,70 +382,108 @@ func (h *PluginHandler) Import(w http.ResponseWriter, r *http.Request) {
 }
 
 // ensurePluginCategory ensures the plugin's category and attributes exist
-func (h *PluginHandler) ensurePluginCategory(r *http.Request, p domain.ImportPlugin) (*domain.Category, error) {
-	ctx := r.Context()
+func (h *PluginHandler) ensurePluginCategory(ctx context.Context, p domain.ImportPlugin) (*domain.Category, bool, error) {
+	return ensurePluginCategory(ctx, h.repos.Categories, h.repos.Attributes, h.orgID, p)
+}
+
+func ensurePluginCategory(
+	ctx context.Context,
+	categories pluginCategoryRepository,
+	attributes pluginAttributeRepository,
+	organizationID uuid.UUID,
+	p domain.ImportPlugin,
+) (*domain.Category, bool, error) {
 	pluginID := p.ID()
 
 	// Check if category already exists
-	cat, err := h.repos.Categories.GetByPluginID(ctx, h.orgID, pluginID)
+	cat, err := categories.GetByPluginID(ctx, organizationID, pluginID)
 	if err != nil {
-		return nil, err
+		return nil, false, err
 	}
 
-	if cat != nil {
-		return cat, nil
+	created := cat == nil
+	if created {
+		cat = &domain.Category{
+			OrganizationID: organizationID,
+			PluginID:       &pluginID,
+			Name:           p.CategoryName(),
+			Description:    strPtr(p.CategoryDescription()),
+		}
+
+		if err := categories.Create(ctx, cat); err != nil {
+			return nil, false, err
+		}
 	}
 
-	// Create category
-	cat = &domain.Category{
-		OrganizationID: h.orgID,
-		PluginID:       &pluginID,
-		Name:           p.CategoryName(),
-		Description:    strPtr(p.CategoryDescription()),
+	categoryWithAttributes, err := categories.GetByIDWithAttributes(ctx, cat.ID)
+	if err != nil {
+		return nil, false, err
 	}
-
-	if err := h.repos.Categories.Create(ctx, cat); err != nil {
-		return nil, err
+	if categoryWithAttributes == nil {
+		return nil, false, fmt.Errorf("category %s disappeared during initialization", cat.ID)
 	}
+	cat = categoryWithAttributes
 
-	// Create plugin attributes
+	// Preserve user-defined fields and add any plugin fields that are missing.
 	pluginAttrs := p.Attributes()
-	assignments := make([]domain.CategoryAttributeAssignment, 0, len(pluginAttrs))
+	assignments := make([]domain.CategoryAttributeAssignment, 0, len(cat.Attributes)+len(pluginAttrs))
+	assignedAttributeIDs := make(map[uuid.UUID]struct{}, len(cat.Attributes))
+	maxSortOrder := -1
+	for _, categoryAttribute := range cat.Attributes {
+		assignments = append(assignments, domain.CategoryAttributeAssignment{
+			AttributeID: categoryAttribute.AttributeID,
+			Required:    categoryAttribute.Required,
+			SortOrder:   categoryAttribute.SortOrder,
+		})
+		assignedAttributeIDs[categoryAttribute.AttributeID] = struct{}{}
+		if categoryAttribute.SortOrder > maxSortOrder {
+			maxSortOrder = categoryAttribute.SortOrder
+		}
+	}
+	assignmentsChanged := false
 
-	for i, pa := range pluginAttrs {
+	for _, pa := range pluginAttrs {
 		// Check if attribute already exists
-		attr, err := h.repos.Attributes.GetByKey(ctx, h.orgID, pa.Key)
+		attr, err := attributes.GetByKey(ctx, organizationID, pa.Key)
 		if err != nil {
-			return nil, err
+			return nil, false, err
 		}
 
 		if attr == nil {
 			// Create the attribute
 			attr = &domain.Attribute{
-				OrganizationID: h.orgID,
+				OrganizationID: organizationID,
 				PluginID:       &pluginID,
 				Name:           pa.Name,
 				Key:            pa.Key,
 				DataType:       pa.DataType,
 			}
-			if err := h.repos.Attributes.Create(ctx, attr); err != nil {
-				return nil, err
+			if err := attributes.Create(ctx, attr); err != nil {
+				return nil, false, err
 			}
 		}
 
+		if _, assigned := assignedAttributeIDs[attr.ID]; assigned {
+			continue
+		}
+
+		maxSortOrder++
 		assignments = append(assignments, domain.CategoryAttributeAssignment{
 			AttributeID: attr.ID,
 			Required:    pa.Required,
-			SortOrder:   i,
+			SortOrder:   maxSortOrder,
 		})
+		assignedAttributeIDs[attr.ID] = struct{}{}
+		assignmentsChanged = true
 	}
 
-	// Assign attributes to category
-	if err := h.repos.Categories.SetAttributes(ctx, cat.ID, assignments); err != nil {
-		return nil, err
+	if assignmentsChanged {
+		if err := categories.SetAttributes(ctx, cat.ID, assignments); err != nil {
+			return nil, false, err
+		}
 	}
 
-	return cat, nil
+	return cat, created, nil
 }
 
 func strPtr(s string) *string {

--- a/backend/internal/handler/plugin_test.go
+++ b/backend/internal/handler/plugin_test.go
@@ -17,28 +17,28 @@ import (
 
 // mockPlugin implements ImportPlugin interface for testing
 type mockPlugin struct {
-	id             string
-	name           string
-	description    string
-	categoryName   string
-	categoryDesc   string
-	searchFields   []domain.SearchField
-	attributes     []domain.PluginAttribute
-	searchResults  []domain.SearchResult
-	searchErr      error
-	fetchData      *domain.ImportData
-	fetchErr       error
+	id            string
+	name          string
+	description   string
+	categoryName  string
+	categoryDesc  string
+	searchFields  []domain.SearchField
+	attributes    []domain.PluginAttribute
+	searchResults []domain.SearchResult
+	searchErr     error
+	fetchData     *domain.ImportData
+	fetchErr      error
 }
 
-func (m *mockPlugin) ID() string                              { return m.id }
-func (m *mockPlugin) Name() string                            { return m.name }
-func (m *mockPlugin) Description() string                     { return m.description }
-func (m *mockPlugin) Enabled() bool                           { return true }
-func (m *mockPlugin) DisabledReason() string                  { return "" }
-func (m *mockPlugin) CategoryName() string                    { return m.categoryName }
-func (m *mockPlugin) CategoryDescription() string             { return m.categoryDesc }
-func (m *mockPlugin) SearchFields() []domain.SearchField      { return m.searchFields }
-func (m *mockPlugin) Attributes() []domain.PluginAttribute    { return m.attributes }
+func (m *mockPlugin) ID() string                           { return m.id }
+func (m *mockPlugin) Name() string                         { return m.name }
+func (m *mockPlugin) Description() string                  { return m.description }
+func (m *mockPlugin) Enabled() bool                        { return true }
+func (m *mockPlugin) DisabledReason() string               { return "" }
+func (m *mockPlugin) CategoryName() string                 { return m.categoryName }
+func (m *mockPlugin) CategoryDescription() string          { return m.categoryDesc }
+func (m *mockPlugin) SearchFields() []domain.SearchField   { return m.searchFields }
+func (m *mockPlugin) Attributes() []domain.PluginAttribute { return m.attributes }
 
 func (m *mockPlugin) Search(ctx context.Context, field, query string, limit int) ([]domain.SearchResult, error) {
 	if m.searchErr != nil {
@@ -85,13 +85,16 @@ func (r *mockPluginRegistry) List() []domain.ImportPlugin {
 // mockCategoryRepoForPlugin extends category repo for plugin tests
 type mockCategoryRepoForPlugin struct {
 	*mockCategoryRepo
-	byPluginID map[string]*domain.Category
+	byPluginID         map[string]*domain.Category
+	assignments        map[uuid.UUID][]domain.CategoryAttributeAssignment
+	setAttributesCalls int
 }
 
 func newMockCategoryRepoForPlugin() *mockCategoryRepoForPlugin {
 	return &mockCategoryRepoForPlugin{
 		mockCategoryRepo: newMockCategoryRepo(),
 		byPluginID:       make(map[string]*domain.Category),
+		assignments:      make(map[uuid.UUID][]domain.CategoryAttributeAssignment),
 	}
 }
 
@@ -99,7 +102,29 @@ func (m *mockCategoryRepoForPlugin) GetByPluginID(ctx context.Context, orgID uui
 	return m.byPluginID[pluginID], nil
 }
 
-func (m *mockCategoryRepoForPlugin) SetAttributes(ctx context.Context, categoryID uuid.UUID, assignments []domain.CategoryAttributeAssignment) error {
+func (m *mockCategoryRepoForPlugin) Create(ctx context.Context, category *domain.Category) error {
+	if err := m.mockCategoryRepo.Create(ctx, category); err != nil {
+		return err
+	}
+	if category.PluginID != nil {
+		m.byPluginID[*category.PluginID] = category
+	}
+	return nil
+}
+
+func (m *mockCategoryRepoForPlugin) SetAttributes(_ context.Context, categoryID uuid.UUID, assignments []domain.CategoryAttributeAssignment) error {
+	m.setAttributesCalls++
+	m.assignments[categoryID] = append([]domain.CategoryAttributeAssignment(nil), assignments...)
+	category := m.categories[categoryID]
+	category.Attributes = make([]domain.CategoryAttribute, 0, len(assignments))
+	for _, assignment := range assignments {
+		category.Attributes = append(category.Attributes, domain.CategoryAttribute{
+			CategoryID:  categoryID,
+			AttributeID: assignment.AttributeID,
+			Required:    assignment.Required,
+			SortOrder:   assignment.SortOrder,
+		})
+	}
 	return nil
 }
 
@@ -332,6 +357,54 @@ func withPluginChiURLParam(r *http.Request, key, value string) *http.Request {
 	rctx := chi.NewRouteContext()
 	rctx.URLParams.Add(key, value)
 	return r.WithContext(context.WithValue(r.Context(), chi.RouteCtxKey, rctx))
+}
+
+func TestEnsurePluginCategoryCreatesCategoryAndAttributesOnce(t *testing.T) {
+	h := newTestPluginHandler()
+	p := &mockPlugin{
+		id:           "google_books",
+		name:         "Google Books",
+		categoryName: "Books",
+		categoryDesc: "Books imported from Google Books",
+		attributes: []domain.PluginAttribute{
+			{Key: "books.isbn", Name: "ISBN", DataType: domain.AttributeTypeString},
+			{Key: "books.author", Name: "Author", DataType: domain.AttributeTypeString},
+		},
+	}
+
+	category, created, err := ensurePluginCategory(t.Context(), h.categoryRepo, h.attrRepo, h.orgID, p)
+	if err != nil {
+		t.Fatalf("initializing plugin category: %v", err)
+	}
+	if !created {
+		t.Fatal("expected category to be created")
+	}
+	if category.Name != "Books" || category.PluginID == nil || *category.PluginID != p.ID() {
+		t.Fatalf("unexpected category: %#v", category)
+	}
+	if len(h.attrRepo.attributes) != 2 {
+		t.Fatalf("expected 2 plugin attributes, got %d", len(h.attrRepo.attributes))
+	}
+	if len(h.categoryRepo.assignments[category.ID]) != 2 {
+		t.Fatalf("expected 2 category assignments, got %d", len(h.categoryRepo.assignments[category.ID]))
+	}
+	if h.categoryRepo.setAttributesCalls != 1 {
+		t.Fatalf("expected attributes to be assigned once, got %d calls", h.categoryRepo.setAttributesCalls)
+	}
+
+	existing, created, err := ensurePluginCategory(t.Context(), h.categoryRepo, h.attrRepo, h.orgID, p)
+	if err != nil {
+		t.Fatalf("reinitializing plugin category: %v", err)
+	}
+	if created {
+		t.Fatal("expected existing category to be reused")
+	}
+	if existing.ID != category.ID {
+		t.Fatalf("expected category %s to be reused, got %s", category.ID, existing.ID)
+	}
+	if h.categoryRepo.setAttributesCalls != 1 {
+		t.Fatalf("expected complete category to remain unchanged, got %d assignment calls", h.categoryRepo.setAttributesCalls)
+	}
 }
 
 // Tests for ListPlugins

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,3 +1,6 @@
+# This file starts development dependencies. The backend runs on the host and
+# reads plugin credentials from its environment, for example:
+#   ATTIC_GOOGLE_BOOKS_API_KEY=... ATTIC_TMDB_API_KEY=... make dev
 services:
   postgres:
     image: postgres:16-alpine

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,6 +27,9 @@ services:
       - ATTIC_BASE_URL=${ATTIC_BASE_URL:-http://localhost:8080}
       - ATTIC_SESSION_SECRET=${ATTIC_SESSION_SECRET}
       - ATTIC_CORS_ORIGINS=${ATTIC_CORS_ORIGINS:-http://localhost:8080}
+      - ATTIC_GOOGLE_BOOKS_API_KEY=${ATTIC_GOOGLE_BOOKS_API_KEY:-}
+      - ATTIC_TMDB_API_KEY=${ATTIC_TMDB_API_KEY:-}
+      - ATTIC_BGG_API_KEY=${ATTIC_BGG_API_KEY:-}
     volumes:
       - attic_uploads:/data/uploads
     depends_on:

--- a/frontend/app/pages/plugins.vue
+++ b/frontend/app/pages/plugins.vue
@@ -9,7 +9,7 @@ const { data: pluginsData, status } = useApi<PluginsResponse>('/api/plugins')
 
 const plugins = computed(() => pluginsData.value?.plugins || [])
 const activePlugins = computed(() => plugins.value.filter(plugin => getPluginStatus(plugin) === 'active').length)
-const availablePlugins = computed(() => plugins.value.filter(plugin => getPluginStatus(plugin) === 'available').length)
+const pluginsNeedingSetup = computed(() => plugins.value.filter(plugin => getPluginStatus(plugin) === 'disabled').length)
 const importModalOpen = ref(false)
 const selectedPluginId = ref<string>()
 
@@ -42,11 +42,8 @@ function getPluginIcon(plugin: Plugin): string {
   return 'i-lucide-database-zap'
 }
 
-function getPluginStatus(plugin: Plugin): 'active' | 'available' | 'disabled' {
-  if (!plugin.enabled) {
-    return 'disabled'
-  }
-  return plugin.category_id ? 'active' : 'available'
+function getPluginStatus(plugin: Plugin): 'active' | 'disabled' {
+  return plugin.enabled ? 'active' : 'disabled'
 }
 
 // Get attribute color based on index for visual variety
@@ -79,18 +76,18 @@ function getAttributeStyle(index: number): { bg: string, text: string, border: s
       <div class="attic-panel flex divide-x divide-mist-100 rounded-xl px-2 py-2 dark:divide-mist-700">
         <div class="px-3">
           <p class="text-[10px] font-bold uppercase text-muted">
-            Available
+            Active
           </p>
           <p class="font-black text-mist-950 dark:text-white">
-            {{ availablePlugins }}
+            {{ activePlugins }}
           </p>
         </div>
         <div class="px-3">
           <p class="text-[10px] font-bold uppercase text-muted">
-            In use
+            Needs setup
           </p>
           <p class="font-black text-mist-950 dark:text-white">
-            {{ activePlugins }}
+            {{ pluginsNeedingSetup }}
           </p>
         </div>
       </div>
@@ -169,11 +166,10 @@ function getAttributeStyle(index: number): { bg: string, text: string, border: s
             class="px-2.5 py-0.5 rounded-full text-xs font-semibold border"
             :class="{
               'bg-emerald-50 dark:bg-emerald-900/20 text-emerald-600 dark:text-emerald-400 border-emerald-100 dark:border-emerald-800/30': getPluginStatus(plugin) === 'active',
-              'bg-mist-100 dark:bg-mist-700 text-mist-600 dark:text-mist-300 border-mist-200 dark:border-mist-600': getPluginStatus(plugin) === 'available',
               'bg-amber-50 dark:bg-amber-900/20 text-amber-600 dark:text-amber-400 border-amber-100 dark:border-amber-800/30': getPluginStatus(plugin) === 'disabled'
             }"
           >
-            {{ getPluginStatus(plugin) === 'active' ? 'Active' : getPluginStatus(plugin) === 'available' ? 'Available' : 'Disabled' }}
+            {{ getPluginStatus(plugin) === 'active' ? 'Active' : 'Needs setup' }}
           </span>
         </div>
 
@@ -199,6 +195,12 @@ function getAttributeStyle(index: number): { bg: string, text: string, border: s
                 class="px-1.5 py-0.5 rounded bg-emerald-50 dark:bg-emerald-900/20 text-emerald-600 dark:text-emerald-400 text-[10px] font-bold uppercase"
               >
                 Created
+              </span>
+              <span
+                v-else
+                class="text-[10px] font-semibold text-muted"
+              >
+                {{ plugin.enabled ? 'Initialization failed' : 'Created when enabled' }}
               </span>
             </div>
             <span class="text-[11px] font-semibold text-muted">

--- a/frontend/tests/pages/management-pages.test.ts
+++ b/frontend/tests/pages/management-pages.test.ts
@@ -46,14 +46,10 @@ describe('management page workflows', () => {
     expect(getStatus(new Date('2026-08-01T12:00:00Z'), now)).toBe('expired')
   })
 
-  it('reports plugin readiness from enabled and category state', () => {
-    const getStatus = (plugin: { enabled: boolean, category_id?: string }) => {
-      if (!plugin.enabled) return 'disabled'
-      return plugin.category_id ? 'active' : 'available'
-    }
+  it('reports plugin readiness independently from category creation', () => {
+    const getStatus = (plugin: { enabled: boolean }) => plugin.enabled ? 'active' : 'disabled'
 
     expect(getStatus({ enabled: false })).toBe('disabled')
-    expect(getStatus({ enabled: true })).toBe('available')
-    expect(getStatus({ enabled: true, category_id: 'books' })).toBe('active')
+    expect(getStatus({ enabled: true })).toBe('active')
   })
 })


### PR DESCRIPTION
## Overview

Improve plugin setup visibility and initialization during application startup.

Attic now reports plugin configuration status in the logs and automatically creates the categories and metadata fields required by enabled import plugins.

## Changes

- Log each registered plugin during startup.
- Report:
  - Plugin ID and name.
  - Whether the plugin is enabled.
  - The API-key environment variable used.
  - Whether the environment variable is set.
- Never log API-key values.
- Initialize categories for enabled plugins during startup.
- Create missing plugin attributes automatically.
- Reuse existing plugin categories safely.
- Preserve existing category attributes and user customizations.
- Report whether each category was newly created or already existed.
- Keep import-time category initialization as a fallback.
- Update the plugins page to distinguish plugin readiness from category creation.
- Add Google Books, TMDB, and BoardGameGeek variables to Compose and `.env.example`.
- Update the development Compose documentation.
- Update the import-plugin documentation to reflect startup category initialization.

## Example startup output

This helps users understand if the system found the env variable

```json
{
  "msg": "registered import plugin",
  "plugin_id": "tmdb_movies",
  "enabled": true,
  "api_key_environment_variable": "ATTIC_TMDB_API_KEY",
  "api_key_set": true
}

{
  "msg": "initialized plugin category",
  "plugin_id": "google_books",
  "category_name": "Books",
  "created": true
}
```

  ## Configuration

```
ATTIC_GOOGLE_BOOKS_API_KEY=your-google-books-api-key
ATTIC_TMDB_API_KEY=your-tmdb-api-key
ATTIC_BGG_API_KEY=your-boardgamegeek-api-key
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Plugin categories are now initialized automatically when enabled, creating missing attributes while preserving existing customizations.
  * Optional Google Books, TMDB, and BoardGameGeek API keys can be configured for import plugins.

* **Improvements**
  * Plugin status now clearly distinguishes active plugins from those needing setup.
  * Plugin cards provide clearer feedback when initialization fails or when setup will occur after enabling.
  * Development setup documentation now explains dependency startup and credential configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->