### PR TITLE
feat(frontend): show backend version in authenticated footer

### DIFF
--- a/frontend/app/app.vue
+++ b/frontend/app/app.vue
@@ -23,6 +23,22 @@ useSeoMeta({
 
 const { isAuthenticated: loggedIn, user, isAdmin, logout, fetchSession, isOIDCEnabled, changePassword } = useAuth()
 
+type AppInfo = {
+  status: string
+  version: string
+}
+
+const { data: appInfo, execute: fetchAppInfo } = useApi<AppInfo>('/api/', {
+  immediate: false
+})
+const softwareVersion = computed(() => appInfo.value?.version || 'unknown')
+
+watch(loggedIn, (isLoggedIn) => {
+  if (isLoggedIn) {
+    void fetchAppInfo()
+  }
+}, { immediate: true })
+
 // Fetch session on app load
 onMounted(() => {
   fetchSession()
@@ -425,8 +441,14 @@ const isAssetForm = computed(() => /^\/assets\/(?:new|[^/]+\/edit)\/?$/.test(rou
 
           <!-- Scrollable content -->
           <div class="flex-1 overflow-y-auto custom-scrollbar p-4 md:p-6 xl:p-7">
-            <div class="max-w-[1440px] mx-auto">
-              <NuxtPage />
+            <div class="mx-auto flex min-h-full max-w-[1440px] flex-col">
+              <div class="flex-1">
+                <NuxtPage />
+              </div>
+
+              <footer class="shrink-0 pt-6 text-center text-xs font-medium text-muted dark:text-mist-400">
+                Attic version {{ softwareVersion }}
+              </footer>
             </div>
           </div>
         </main>

--- a/frontend/tests/app/footer.test.ts
+++ b/frontend/tests/app/footer.test.ts
@@ -1,0 +1,17 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+describe('authenticated app footer', () => {
+  const source = readFileSync(resolve(process.cwd(), 'app/app.vue'), 'utf8')
+
+  it('loads and displays the running backend version', () => {
+    expect(source).toContain('useApi<AppInfo>(\'/api/\'')
+    expect(source).toContain('Attic version {{ softwareVersion }}')
+  })
+
+  it('stays at the bottom when page content is short', () => {
+    expect(source).toContain('mx-auto flex min-h-full max-w-[1440px] flex-col')
+    expect(source).toContain('<div class="flex-1">')
+  })
+})


### PR DESCRIPTION
## Summary

- Display the running backend version in the authenticated frontend footer.
- Fetch the version from the authenticated `/api/` endpoint.
- Keep the footer at the bottom of short pages while allowing it to follow longer content.
- Add regression tests for version loading and sticky footer layout.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a footer to authenticated pages displaying the application version.
  - Version information is loaded from the backend and shows “unknown” when unavailable.
  - Updated the authenticated layout to keep the footer positioned at the bottom of short pages.

- **Tests**
  - Added coverage for version display and footer positioning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->