### PR TITLE
feat(frontend): add API Swagger link to authenticated footer

### DIFF
--- a/frontend/app/app.vue
+++ b/frontend/app/app.vue
@@ -22,6 +22,7 @@ useSeoMeta({
 })
 
 const { isAuthenticated: loggedIn, user, isAdmin, logout, fetchSession, isOIDCEnabled, changePassword } = useAuth()
+const config = useRuntimeConfig()
 
 type AppInfo = {
   status: string
@@ -32,6 +33,7 @@ const { data: appInfo, execute: fetchAppInfo } = useApi<AppInfo>('/api/', {
   immediate: false
 })
 const softwareVersion = computed(() => appInfo.value?.version || 'unknown')
+const apiDocsUrl = computed(() => `${config.public.apiBase || ''}/api/docs`)
 
 watch(loggedIn, (isLoggedIn) => {
   if (isLoggedIn) {
@@ -447,7 +449,16 @@ const isAssetForm = computed(() => /^\/assets\/(?:new|[^/]+\/edit)\/?$/.test(rou
               </div>
 
               <footer class="shrink-0 pt-6 text-center text-xs font-medium text-muted dark:text-mist-400">
-                Attic version {{ softwareVersion }}
+                <span>Attic version {{ softwareVersion }}</span>
+                <span class="mx-2 text-mist-300 dark:text-mist-600">·</span>
+                <a
+                  :href="apiDocsUrl"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  class="text-attic-600 underline decoration-attic-300 underline-offset-2 transition-colors hover:text-attic-700 dark:text-attic-300 dark:decoration-attic-500 dark:hover:text-attic-200"
+                >
+                  API
+                </a>
               </footer>
             </div>
           </div>

--- a/frontend/tests/app/footer.test.ts
+++ b/frontend/tests/app/footer.test.ts
@@ -8,6 +8,8 @@ describe('authenticated app footer', () => {
   it('loads and displays the running backend version', () => {
     expect(source).toContain('useApi<AppInfo>(\'/api/\'')
     expect(source).toContain('Attic version {{ softwareVersion }}')
+    expect(source).toContain(':href="apiDocsUrl"')
+    expect(source).toContain('API')
   })
 
   it('stays at the bottom when page content is short', () => {


### PR DESCRIPTION
## Summary

- Display the running backend version in the authenticated frontend footer.
- Add an API Swagger documentation link next to the version.
- Build the Swagger URL from the configured API base URL.
- Open Swagger documentation in a new secure browser tab.
- Keep the footer at the bottom of short pages.
- Add regression tests for the footer content and layout.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an external API documentation link to the application footer.
  - The link is generated from the public runtime configuration and opens securely in a new tab.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->