### PR TITLE
feat(plugins): add IGDB video game importer

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -74,6 +74,9 @@ KEYCLOAK_DB=keycloak
 # ATTIC_GOOGLE_BOOKS_API_KEY=your-google-books-api-key
 # ATTIC_TMDB_API_KEY=your-tmdb-api-key
 # ATTIC_BGG_API_KEY=your-boardgamegeek-api-key
+# IGDB requires both credentials from a Twitch application
+# ATTIC_IGDB_CLIENT_ID=your-twitch-client-id
+# ATTIC_IGDB_CLIENT_SECRET=your-twitch-client-secret
 
 # --------------------------------------
 # Local Storage Configuration

--- a/README.md
+++ b/README.md
@@ -22,13 +22,17 @@ Attic mirrors the way a home is organized with nested locations such as rooms, s
 - Filter by category, location, and condition
 
 **Smart Integrations**
-- Automated imports from Google Books, TMDB (movies), and BoardGameGeek
+- Automated imports from Google Books, TMDB (movies and TV), BoardGameGeek, and IGDB (video games)
 - Metadata and cover images populated automatically
 - Plugin system for adding new import sources
 
 Google Books works without credentials, but Google may apply a low shared quota to unauthenticated
 requests. Set `ATTIC_GOOGLE_BOOKS_API_KEY` to a Google Books API key for reliable imports in a
 self-hosted or shared deployment. The key is sent only to Google Books API requests.
+
+IGDB imports require `ATTIC_IGDB_CLIENT_ID` and `ATTIC_IGDB_CLIENT_SECRET` from a
+[Twitch application](https://dev.twitch.tv/console/apps). Attic exchanges these credentials for a
+short-lived access token and keeps the token in memory only.
 
 **Self-Hosted & Secure**
 - Docker-based deployment with complete data ownership

--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -25,6 +25,7 @@ import (
 	"github.com/lmmendes/attic/internal/plugin"
 	"github.com/lmmendes/attic/internal/plugin/bgg"
 	"github.com/lmmendes/attic/internal/plugin/googlebooks"
+	"github.com/lmmendes/attic/internal/plugin/igdb"
 	"github.com/lmmendes/attic/internal/plugin/tmdb"
 	"github.com/lmmendes/attic/internal/repository"
 	"github.com/lmmendes/attic/internal/storage"
@@ -200,6 +201,7 @@ func main() {
 	registerImportPlugin(pluginRegistry, tmdb.NewMoviesPlugin(), "ATTIC_TMDB_API_KEY")
 	registerImportPlugin(pluginRegistry, tmdb.NewSeriesPlugin(), "ATTIC_TMDB_API_KEY")
 	registerImportPlugin(pluginRegistry, bgg.New(), "ATTIC_BGG_API_KEY")
+	registerImportPlugin(pluginRegistry, igdb.New(), "ATTIC_IGDB_CLIENT_ID")
 	slog.Info("registered plugins", "count", len(pluginRegistry.List()))
 
 	// Initialize handlers

--- a/backend/internal/plugin/igdb/auth.go
+++ b/backend/internal/plugin/igdb/auth.go
@@ -1,0 +1,151 @@
+package igdb
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"sync"
+	"time"
+)
+
+const (
+	twitchTokenURL          = "https://id.twitch.tv/oauth2/token"
+	clientIDEnvVar          = "ATTIC_IGDB_CLIENT_ID"
+	clientSecretEnvVar      = "ATTIC_IGDB_CLIENT_SECRET"
+	tokenRefreshLeeway      = 5 * time.Minute
+	defaultTokenHTTPTimeout = 10 * time.Second
+)
+
+// ClientID and ClientSecret can be set at build time via ldflags:
+// go build -ldflags="-X github.com/lmmendes/attic/internal/plugin/igdb.ClientID=... -X github.com/lmmendes/attic/internal/plugin/igdb.ClientSecret=..."
+var (
+	ClientID     = ""
+	ClientSecret = ""
+)
+
+type tokenResponse struct {
+	AccessToken string `json:"access_token"`
+	ExpiresIn   int64  `json:"expires_in"`
+	TokenType   string `json:"token_type"`
+}
+
+// tokenSource manages the Twitch OAuth token used to authenticate IGDB requests.
+// Tokens are cached in memory and refreshed automatically before expiry.
+type tokenSource struct {
+	httpClient *http.Client
+
+	mu        sync.Mutex
+	token     string
+	expiresAt time.Time
+}
+
+func newTokenSource() *tokenSource {
+	return &tokenSource{
+		httpClient: &http.Client{Timeout: defaultTokenHTTPTimeout},
+	}
+}
+
+// Token returns a valid access token, fetching a new one when necessary.
+func (t *tokenSource) Token(ctx context.Context) (string, error) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	if t.token != "" && time.Until(t.expiresAt) > tokenRefreshLeeway {
+		return t.token, nil
+	}
+
+	clientID, clientSecret := credentials()
+	if clientID == "" || clientSecret == "" {
+		return "", fmt.Errorf("IGDB credentials not configured")
+	}
+
+	tok, err := t.requestToken(ctx, clientID, clientSecret)
+	if err != nil {
+		return "", err
+	}
+
+	t.token = tok.AccessToken
+	t.expiresAt = time.Now().Add(time.Duration(tok.ExpiresIn) * time.Second)
+	return t.token, nil
+}
+
+// Invalidate forces the next Token() call to fetch a fresh token.
+// Use this after receiving a 401 from the IGDB API.
+func (t *tokenSource) Invalidate() {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.token = ""
+	t.expiresAt = time.Time{}
+}
+
+// IsEnabled returns true if both IGDB credentials are configured.
+func IsEnabled() bool {
+	id, secret := credentials()
+	return id != "" && secret != ""
+}
+
+// GetDisabledReason returns the reason the plugin is disabled.
+func GetDisabledReason() string {
+	if IsEnabled() {
+		return ""
+	}
+	id, secret := credentials()
+	missing := make([]string, 0, 2)
+	if id == "" {
+		missing = append(missing, clientIDEnvVar)
+	}
+	if secret == "" {
+		missing = append(missing, clientSecretEnvVar)
+	}
+	return "Missing IGDB credentials: " + strings.Join(missing, ", ")
+}
+
+// Private helpers
+
+func credentials() (string, string) {
+	id := os.Getenv(clientIDEnvVar)
+	if id == "" {
+		id = ClientID
+	}
+	secret := os.Getenv(clientSecretEnvVar)
+	if secret == "" {
+		secret = ClientSecret
+	}
+	return id, secret
+}
+
+func (t *tokenSource) requestToken(ctx context.Context, clientID, clientSecret string) (*tokenResponse, error) {
+	params := url.Values{}
+	params.Set("client_id", clientID)
+	params.Set("client_secret", clientSecret)
+	params.Set("grant_type", "client_credentials")
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, twitchTokenURL+"?"+params.Encode(), nil)
+	if err != nil {
+		return nil, fmt.Errorf("creating token request: %w", err)
+	}
+
+	resp, err := t.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("requesting token: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("token endpoint returned status %d", resp.StatusCode)
+	}
+
+	var tok tokenResponse
+	if err := json.NewDecoder(resp.Body).Decode(&tok); err != nil {
+		return nil, fmt.Errorf("decoding token response: %w", err)
+	}
+	if tok.AccessToken == "" {
+		return nil, fmt.Errorf("token endpoint returned empty token")
+	}
+
+	return &tok, nil
+}

--- a/backend/internal/plugin/igdb/igdb.go
+++ b/backend/internal/plugin/igdb/igdb.go
@@ -1,0 +1,588 @@
+package igdb
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/lmmendes/attic/internal/domain"
+)
+
+const (
+	// PluginID is the unique identifier for this plugin.
+	PluginID = "igdb_games"
+
+	apiBaseURL   = "https://api.igdb.com/v4"
+	imageBaseURL = "https://images.igdb.com/igdb/image/upload"
+
+	defaultLimit        = 10
+	maxPlatformsPerGame = 6
+	rateLimitWindow     = 250 * time.Millisecond // ~4 requests/sec (IGDB's documented cap)
+)
+
+// Plugin implements the IGDB import plugin.
+type Plugin struct {
+	httpClient *http.Client
+	tokens     *tokenSource
+
+	rateMu      sync.Mutex
+	lastRequest time.Time
+}
+
+// New creates a new IGDB plugin instance.
+func New() *Plugin {
+	return &Plugin{
+		httpClient: &http.Client{Timeout: 15 * time.Second},
+		tokens:     newTokenSource(),
+	}
+}
+
+// Plugin metadata
+
+func (p *Plugin) ID() string   { return PluginID }
+func (p *Plugin) Name() string { return "IGDB" }
+func (p *Plugin) Description() string {
+	return "Import video games from the Internet Game Database (IGDB)"
+}
+
+func (p *Plugin) Enabled() bool          { return IsEnabled() }
+func (p *Plugin) DisabledReason() string { return GetDisabledReason() }
+
+func (p *Plugin) CategoryName() string        { return "Video Games" }
+func (p *Plugin) CategoryDescription() string { return "Video games imported from IGDB" }
+
+// Attributes returns the namespaced attributes managed by this plugin.
+func (p *Plugin) Attributes() []domain.PluginAttribute {
+	return []domain.PluginAttribute{
+		{Key: "games.platform", Name: "Platform", DataType: domain.AttributeTypeString, Required: false},
+		{Key: "games.release_date", Name: "Release Date", DataType: domain.AttributeTypeDate, Required: false},
+		{Key: "games.year_released", Name: "Year Released", DataType: domain.AttributeTypeNumber, Required: false},
+		{Key: "games.genres", Name: "Genres", DataType: domain.AttributeTypeString, Required: false},
+		{Key: "games.themes", Name: "Themes", DataType: domain.AttributeTypeString, Required: false},
+		{Key: "games.developers", Name: "Developers", DataType: domain.AttributeTypeString, Required: false},
+		{Key: "games.publishers", Name: "Publishers", DataType: domain.AttributeTypeString, Required: false},
+		{Key: "games.game_modes", Name: "Game Modes", DataType: domain.AttributeTypeString, Required: false},
+		{Key: "games.player_perspectives", Name: "Player Perspective", DataType: domain.AttributeTypeString, Required: false},
+		{Key: "games.franchise", Name: "Franchise", DataType: domain.AttributeTypeString, Required: false},
+		{Key: "games.engine", Name: "Game Engine", DataType: domain.AttributeTypeString, Required: false},
+		{Key: "games.age_rating", Name: "Age Rating", DataType: domain.AttributeTypeString, Required: false},
+		{Key: "games.category", Name: "Edition Type", DataType: domain.AttributeTypeString, Required: false},
+		{Key: "games.status", Name: "Release Status", DataType: domain.AttributeTypeString, Required: false},
+		{Key: "games.rating", Name: "IGDB Rating", DataType: domain.AttributeTypeNumber, Required: false},
+		{Key: "games.url", Name: "IGDB URL", DataType: domain.AttributeTypeString, Required: false},
+	}
+}
+
+// SearchFields returns the searchable fields exposed by this plugin.
+func (p *Plugin) SearchFields() []domain.SearchField {
+	return []domain.SearchField{
+		{Key: "name", Label: "Name"},
+	}
+}
+
+// Search returns one row per (game, platform) combination so users can pick
+// the platform that matches their physical/digital copy when importing.
+//
+// External IDs are encoded as "<gameID>:<platformID>" (or just "<gameID>" when
+// the game has no platform metadata). Fetch parses this composite back apart.
+func (p *Plugin) Search(ctx context.Context, _, query string, limit int) ([]domain.SearchResult, error) {
+	if limit <= 0 || limit > 25 {
+		limit = defaultLimit
+	}
+
+	escapedQuery := escapeSearchQuery(query)
+	body := fmt.Sprintf(
+		`search "%s"; fields name, first_release_date, cover.image_id, platforms.id, platforms.name, release_dates.platform, release_dates.date; limit %d;`,
+		escapedQuery, limit,
+	)
+
+	var games []searchGame
+	if err := p.post(ctx, "/games", body, &games); err != nil {
+		return nil, fmt.Errorf("searching games: %w", err)
+	}
+
+	results := make([]domain.SearchResult, 0, len(games))
+	for _, g := range games {
+		results = append(results, p.expandSearchResult(g)...)
+	}
+	return results, nil
+}
+
+// Fetch retrieves full data for a (game, platform) combination.
+func (p *Plugin) Fetch(ctx context.Context, externalID string) (*domain.ImportData, error) {
+	gameID, platformID, err := parseExternalID(externalID)
+	if err != nil {
+		return nil, err
+	}
+
+	body := fmt.Sprintf(
+		`fields name, summary, storyline, first_release_date, cover.image_id, platforms.name, genres.name, themes.name, game_modes.name, player_perspectives.name, involved_companies.developer, involved_companies.publisher, involved_companies.company.name, rating, age_ratings.organization.name, age_ratings.rating_category.rating, franchises.name, game_engines.name, game_type.type, game_status.status, url, release_dates.platform, release_dates.date; where id = %d; limit 1;`,
+		gameID,
+	)
+
+	var games []fetchGame
+	if err := p.post(ctx, "/games", body, &games); err != nil {
+		return nil, fmt.Errorf("fetching game: %w", err)
+	}
+	if len(games) == 0 {
+		return nil, fmt.Errorf("game not found")
+	}
+	game := games[0]
+
+	data := &domain.ImportData{
+		Name:       game.Name,
+		ExternalID: externalID,
+		Attributes: make(map[string]any),
+	}
+
+	if desc := pickDescription(game.Summary, game.Storyline); desc != "" {
+		data.Description = &desc
+	}
+	if game.Cover.ImageID != "" {
+		img := coverURL(game.Cover.ImageID, "t_cover_big")
+		data.ImageURL = &img
+	}
+
+	releaseDate := selectReleaseDate(game, platformID)
+	if releaseDate != "" {
+		data.Attributes["games.release_date"] = releaseDate
+		if year, err := strconv.Atoi(releaseDate[:4]); err == nil {
+			data.Attributes["games.year_released"] = year
+		}
+	}
+
+	if platformName := selectPlatformName(game.Platforms, platformID); platformName != "" {
+		data.Attributes["games.platform"] = platformName
+	}
+
+	if v := joinNamed(game.Genres); v != "" {
+		data.Attributes["games.genres"] = v
+	}
+	if v := joinNamed(game.Themes); v != "" {
+		data.Attributes["games.themes"] = v
+	}
+	if v := joinNamed(game.GameModes); v != "" {
+		data.Attributes["games.game_modes"] = v
+	}
+	if v := joinNamed(game.PlayerPerspectives); v != "" {
+		data.Attributes["games.player_perspectives"] = v
+	}
+	if v := joinNamed(game.Franchises); v != "" {
+		data.Attributes["games.franchise"] = v
+	}
+	if v := joinNamed(game.GameEngines); v != "" {
+		data.Attributes["games.engine"] = v
+	}
+
+	developers, publishers := splitCompanies(game.InvolvedCompanies)
+	if developers != "" {
+		data.Attributes["games.developers"] = developers
+	}
+	if publishers != "" {
+		data.Attributes["games.publishers"] = publishers
+	}
+
+	if rating := formatAgeRatings(game.AgeRatings); rating != "" {
+		data.Attributes["games.age_rating"] = rating
+	}
+
+	if game.GameType.Type != "" {
+		data.Attributes["games.category"] = game.GameType.Type
+	}
+	if game.GameStatus.Status != "" {
+		data.Attributes["games.status"] = game.GameStatus.Status
+	}
+
+	if game.Rating > 0 {
+		// IGDB returns rating as a 0-100 float; round to one decimal for readability.
+		data.Attributes["games.rating"] = roundTo(game.Rating, 1)
+	}
+	if game.URL != "" {
+		data.Attributes["games.url"] = game.URL
+	}
+
+	return data, nil
+}
+
+// Private helpers
+
+// post executes an Apicalypse query against IGDB and decodes the JSON result.
+// It transparently refreshes the auth token once on a 401.
+func (p *Plugin) post(ctx context.Context, endpoint, body string, result any) error {
+	resp, err := p.doRequest(ctx, endpoint, body, false)
+	if err != nil {
+		return err
+	}
+
+	if resp.StatusCode == http.StatusUnauthorized {
+		// Token may have been revoked or rotated; force-refresh and retry once.
+		resp.Body.Close()
+		p.tokens.Invalidate()
+		resp, err = p.doRequest(ctx, endpoint, body, true)
+		if err != nil {
+			return err
+		}
+	}
+
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		preview, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
+		return fmt.Errorf("IGDB API returned status %d: %s", resp.StatusCode, strings.TrimSpace(string(preview)))
+	}
+
+	if err := json.NewDecoder(resp.Body).Decode(result); err != nil {
+		return fmt.Errorf("decoding response: %w", err)
+	}
+	return nil
+}
+
+func (p *Plugin) doRequest(ctx context.Context, endpoint, body string, isRetry bool) (*http.Response, error) {
+	token, err := p.tokens.Token(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	clientID, _ := credentials()
+
+	if err := p.waitForRateLimit(ctx); err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, apiBaseURL+endpoint, bytes.NewReader([]byte(body)))
+	if err != nil {
+		return nil, fmt.Errorf("creating request: %w", err)
+	}
+	req.Header.Set("Client-ID", clientID)
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("Content-Type", "text/plain")
+
+	resp, err := p.httpClient.Do(req)
+	if err != nil {
+		if isRetry {
+			return nil, fmt.Errorf("retry request failed: %w", err)
+		}
+		return nil, fmt.Errorf("executing request: %w", err)
+	}
+	return resp, nil
+}
+
+func (p *Plugin) waitForRateLimit(ctx context.Context) error {
+	p.rateMu.Lock()
+	defer p.rateMu.Unlock()
+
+	elapsed := time.Since(p.lastRequest)
+	if elapsed < rateLimitWindow {
+		timer := time.NewTimer(rateLimitWindow - elapsed)
+		defer timer.Stop()
+		select {
+		case <-timer.C:
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+	p.lastRequest = time.Now()
+	return nil
+}
+
+// expandSearchResult turns one game into one row per relevant platform, capped
+// at maxPlatformsPerGame and sorted so the most recent releases come first.
+func (p *Plugin) expandSearchResult(g searchGame) []domain.SearchResult {
+	year := extractYear(g.FirstReleaseDate)
+
+	base := domain.SearchResult{
+		Title: g.Name,
+	}
+	if g.Cover.ImageID != "" {
+		img := coverURL(g.Cover.ImageID, "t_cover_small")
+		base.ImageURL = &img
+	}
+
+	if len(g.Platforms) == 0 {
+		// No platform info – fall back to a single row keyed by game ID only.
+		base.ExternalID = strconv.FormatInt(g.ID, 10)
+		base.Subtitle = formatSubtitle("", year)
+		return []domain.SearchResult{base}
+	}
+
+	platforms := selectTopPlatforms(g)
+
+	results := make([]domain.SearchResult, 0, len(platforms))
+	for _, plat := range platforms {
+		row := base
+		row.ExternalID = fmt.Sprintf("%d:%d", g.ID, plat.ID)
+		platformYear := year
+		if plat.ReleaseUnix > 0 {
+			platformYear = extractYear(plat.ReleaseUnix)
+		}
+		row.Subtitle = formatSubtitle(plat.Name, platformYear)
+		results = append(results, row)
+	}
+	return results
+}
+
+// selectTopPlatforms picks up to maxPlatformsPerGame platforms, preferring those
+// with the most recent release date for this game.
+func selectTopPlatforms(g searchGame) []platformWithRelease {
+	releaseByPlatform := make(map[int64]int64, len(g.ReleaseDates))
+	for _, rd := range g.ReleaseDates {
+		if rd.Date > releaseByPlatform[rd.Platform] {
+			releaseByPlatform[rd.Platform] = rd.Date
+		}
+	}
+
+	enriched := make([]platformWithRelease, 0, len(g.Platforms))
+	for _, plat := range g.Platforms {
+		enriched = append(enriched, platformWithRelease{
+			ID:          plat.ID,
+			Name:        plat.Name,
+			ReleaseUnix: releaseByPlatform[plat.ID],
+		})
+	}
+
+	sort.SliceStable(enriched, func(i, j int) bool {
+		if enriched[i].ReleaseUnix != enriched[j].ReleaseUnix {
+			return enriched[i].ReleaseUnix > enriched[j].ReleaseUnix
+		}
+		return enriched[i].Name < enriched[j].Name
+	})
+
+	if len(enriched) > maxPlatformsPerGame {
+		enriched = enriched[:maxPlatformsPerGame]
+	}
+	return enriched
+}
+
+func parseExternalID(externalID string) (int64, int64, error) {
+	parts := strings.SplitN(externalID, ":", 2)
+	gameID, err := strconv.ParseInt(parts[0], 10, 64)
+	if err != nil || gameID <= 0 {
+		return 0, 0, fmt.Errorf("invalid external_id: %q", externalID)
+	}
+	if len(parts) == 1 || parts[1] == "" {
+		return gameID, 0, nil
+	}
+	platformID, err := strconv.ParseInt(parts[1], 10, 64)
+	if err != nil || platformID <= 0 {
+		return 0, 0, fmt.Errorf("invalid platform id in external_id: %q", externalID)
+	}
+	return gameID, platformID, nil
+}
+
+func escapeSearchQuery(query string) string {
+	query = strings.ReplaceAll(query, `\`, `\\`)
+	query = strings.ReplaceAll(query, `"`, `\"`)
+	query = strings.ReplaceAll(query, "\r", " ")
+	return strings.ReplaceAll(query, "\n", " ")
+}
+
+func selectReleaseDate(game fetchGame, platformID int64) string {
+	if platformID > 0 {
+		for _, rd := range game.ReleaseDates {
+			if rd.Platform == platformID && rd.Date > 0 {
+				return formatDate(rd.Date)
+			}
+		}
+	}
+	if game.FirstReleaseDate > 0 {
+		return formatDate(game.FirstReleaseDate)
+	}
+	return ""
+}
+
+func selectPlatformName(platforms []namedRef, platformID int64) string {
+	if platformID == 0 {
+		return ""
+	}
+	for _, p := range platforms {
+		if p.ID == platformID {
+			return p.Name
+		}
+	}
+	return ""
+}
+
+func joinNamed[T namedItem](items []T) string {
+	if len(items) == 0 {
+		return ""
+	}
+	names := make([]string, 0, len(items))
+	for _, it := range items {
+		if n := it.GetName(); n != "" {
+			names = append(names, n)
+		}
+	}
+	return strings.Join(names, ", ")
+}
+
+func splitCompanies(items []involvedCompany) (string, string) {
+	var devs, pubs []string
+	for _, c := range items {
+		name := c.Company.Name
+		if name == "" {
+			continue
+		}
+		if c.Developer {
+			devs = append(devs, name)
+		}
+		if c.Publisher {
+			pubs = append(pubs, name)
+		}
+	}
+	return strings.Join(devs, ", "), strings.Join(pubs, ", ")
+}
+
+func formatAgeRatings(ratings []ageRating) string {
+	if len(ratings) == 0 {
+		return ""
+	}
+	parts := make([]string, 0, len(ratings))
+	for _, r := range ratings {
+		org := r.Organization.Name
+		val := r.RatingCategory.Rating
+		if org == "" || val == "" {
+			continue
+		}
+		parts = append(parts, fmt.Sprintf("%s: %s", org, val))
+	}
+	return strings.Join(parts, ", ")
+}
+
+func pickDescription(summary, storyline string) string {
+	if summary != "" {
+		return summary
+	}
+	return storyline
+}
+
+func coverURL(imageID, size string) string {
+	return fmt.Sprintf("%s/%s/%s.jpg", imageBaseURL, size, imageID)
+}
+
+func formatDate(unix int64) string {
+	if unix <= 0 {
+		return ""
+	}
+	return time.Unix(unix, 0).UTC().Format("2006-01-02")
+}
+
+func extractYear(unix int64) string {
+	if unix <= 0 {
+		return ""
+	}
+	return time.Unix(unix, 0).UTC().Format("2006")
+}
+
+func formatSubtitle(platform, year string) string {
+	switch {
+	case platform != "" && year != "":
+		return fmt.Sprintf("%s (%s)", platform, year)
+	case platform != "":
+		return platform
+	case year != "":
+		return fmt.Sprintf("(%s)", year)
+	}
+	return ""
+}
+
+func roundTo(value float64, decimals int) float64 {
+	mult := 1.0
+	for i := 0; i < decimals; i++ {
+		mult *= 10
+	}
+	return float64(int64(value*mult+0.5)) / mult
+}
+
+// IGDB response types
+
+type namedItem interface {
+	GetName() string
+}
+
+type namedRef struct {
+	ID   int64  `json:"id"`
+	Name string `json:"name"`
+}
+
+func (n namedRef) GetName() string { return n.Name }
+
+type platformWithRelease struct {
+	ID          int64
+	Name        string
+	ReleaseUnix int64
+}
+
+type cover struct {
+	ImageID string `json:"image_id"`
+}
+
+type releaseDate struct {
+	Platform int64 `json:"platform"`
+	Date     int64 `json:"date"`
+}
+
+type involvedCompany struct {
+	Developer bool `json:"developer"`
+	Publisher bool `json:"publisher"`
+	Company   struct {
+		Name string `json:"name"`
+	} `json:"company"`
+}
+
+type ageRating struct {
+	Organization struct {
+		Name string `json:"name"`
+	} `json:"organization"`
+	RatingCategory struct {
+		Rating string `json:"rating"`
+	} `json:"rating_category"`
+}
+
+type gameType struct {
+	Type string `json:"type"`
+}
+
+type gameStatus struct {
+	Status string `json:"status"`
+}
+
+type searchGame struct {
+	ID               int64         `json:"id"`
+	Name             string        `json:"name"`
+	FirstReleaseDate int64         `json:"first_release_date"`
+	Cover            cover         `json:"cover"`
+	Platforms        []namedRef    `json:"platforms"`
+	ReleaseDates     []releaseDate `json:"release_dates"`
+}
+
+type fetchGame struct {
+	ID                 int64             `json:"id"`
+	Name               string            `json:"name"`
+	Summary            string            `json:"summary"`
+	Storyline          string            `json:"storyline"`
+	FirstReleaseDate   int64             `json:"first_release_date"`
+	Cover              cover             `json:"cover"`
+	Platforms          []namedRef        `json:"platforms"`
+	Genres             []namedRef        `json:"genres"`
+	Themes             []namedRef        `json:"themes"`
+	GameModes          []namedRef        `json:"game_modes"`
+	PlayerPerspectives []namedRef        `json:"player_perspectives"`
+	Franchises         []namedRef        `json:"franchises"`
+	GameEngines        []namedRef        `json:"game_engines"`
+	InvolvedCompanies  []involvedCompany `json:"involved_companies"`
+	AgeRatings         []ageRating       `json:"age_ratings"`
+	Rating             float64           `json:"rating"`
+	GameStatus         gameStatus        `json:"game_status"`
+	GameType           gameType          `json:"game_type"`
+	URL                string            `json:"url"`
+	ReleaseDates       []releaseDate     `json:"release_dates"`
+}

--- a/backend/internal/plugin/igdb/igdb_test.go
+++ b/backend/internal/plugin/igdb/igdb_test.go
@@ -1,0 +1,342 @@
+package igdb
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+func response(status int, body string) *http.Response {
+	return &http.Response{
+		StatusCode: status,
+		Header:     make(http.Header),
+		Body:       io.NopCloser(strings.NewReader(body)),
+	}
+}
+
+func Test_parseExternalID_GameAndPlatform_ParsesBoth(t *testing.T) {
+	gameID, platformID, err := parseExternalID("7346:130")
+
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if gameID != 7346 {
+		t.Errorf("expected gameID=7346, got %d", gameID)
+	}
+	if platformID != 130 {
+		t.Errorf("expected platformID=130, got %d", platformID)
+	}
+}
+
+func Test_parseExternalID_GameOnly_ReturnsZeroPlatform(t *testing.T) {
+	gameID, platformID, err := parseExternalID("7346")
+
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if gameID != 7346 {
+		t.Errorf("expected gameID=7346, got %d", gameID)
+	}
+	if platformID != 0 {
+		t.Errorf("expected platformID=0, got %d", platformID)
+	}
+}
+
+func Test_parseExternalID_InvalidGameID_ReturnsError(t *testing.T) {
+	tests := []string{"", "abc", "abc:1", "-1", "0", "0:1"}
+
+	for _, in := range tests {
+		_, _, err := parseExternalID(in)
+		if err == nil {
+			t.Errorf("expected error for input %q", in)
+		}
+	}
+}
+
+func Test_parseExternalID_InvalidPlatformID_ReturnsError(t *testing.T) {
+	_, _, err := parseExternalID("7346:abc")
+	if err == nil {
+		t.Fatal("expected error for non-numeric platform id")
+	}
+}
+
+func Test_formatSubtitle_PlatformAndYear_Combined(t *testing.T) {
+	tests := []struct {
+		platform string
+		year     string
+		want     string
+	}{
+		{"PlayStation 5", "2020", "PlayStation 5 (2020)"},
+		{"PC", "", "PC"},
+		{"", "2017", "(2017)"},
+		{"", "", ""},
+	}
+
+	for _, tt := range tests {
+		got := formatSubtitle(tt.platform, tt.year)
+		if got != tt.want {
+			t.Errorf("formatSubtitle(%q, %q) = %q; want %q", tt.platform, tt.year, got, tt.want)
+		}
+	}
+}
+
+func Test_coverURL_BuildsImageURL(t *testing.T) {
+	got := coverURL("co5w8p", "t_cover_big")
+	want := "https://images.igdb.com/igdb/image/upload/t_cover_big/co5w8p.jpg"
+
+	if got != want {
+		t.Errorf("coverURL mismatch:\n got: %s\nwant: %s", got, want)
+	}
+}
+
+func Test_formatDate_UnixToISO(t *testing.T) {
+	// 2017-03-03 00:00:00 UTC
+	got := formatDate(1488499200)
+	want := "2017-03-03"
+	if got != want {
+		t.Errorf("formatDate = %q; want %q", got, want)
+	}
+
+	if formatDate(0) != "" {
+		t.Errorf("expected empty string for zero unix timestamp")
+	}
+}
+
+func Test_selectTopPlatforms_SortsByReleaseDateDescending(t *testing.T) {
+	g := searchGame{
+		Platforms: []namedRef{
+			{ID: 1, Name: "Old"},
+			{ID: 2, Name: "New"},
+			{ID: 3, Name: "Mid"},
+		},
+		ReleaseDates: []releaseDate{
+			{Platform: 1, Date: 1000},
+			{Platform: 2, Date: 3000},
+			{Platform: 3, Date: 2000},
+		},
+	}
+
+	got := selectTopPlatforms(g)
+
+	if len(got) != 3 {
+		t.Fatalf("expected 3 platforms, got %d", len(got))
+	}
+	if got[0].Name != "New" || got[1].Name != "Mid" || got[2].Name != "Old" {
+		t.Errorf("unexpected order: %+v", got)
+	}
+}
+
+func Test_selectTopPlatforms_CapsToMax(t *testing.T) {
+	g := searchGame{}
+	for i := 1; i <= maxPlatformsPerGame+3; i++ {
+		g.Platforms = append(g.Platforms, namedRef{ID: int64(i), Name: "P"})
+	}
+
+	got := selectTopPlatforms(g)
+
+	if len(got) != maxPlatformsPerGame {
+		t.Errorf("expected %d platforms, got %d", maxPlatformsPerGame, len(got))
+	}
+}
+
+func Test_splitCompanies_PartitionsByRole(t *testing.T) {
+	input := []involvedCompany{
+		{Developer: true, Company: struct {
+			Name string `json:"name"`
+		}{Name: "CD Projekt Red"}},
+		{Publisher: true, Company: struct {
+			Name string `json:"name"`
+		}{Name: "CD Projekt"}},
+		{Developer: true, Publisher: true, Company: struct {
+			Name string `json:"name"`
+		}{Name: "Both"}},
+		{Company: struct {
+			Name string `json:"name"`
+		}{Name: "Neither"}}, // Should be ignored
+	}
+
+	devs, pubs := splitCompanies(input)
+
+	if devs != "CD Projekt Red, Both" {
+		t.Errorf("unexpected developers: %q", devs)
+	}
+	if pubs != "CD Projekt, Both" {
+		t.Errorf("unexpected publishers: %q", pubs)
+	}
+}
+
+func Test_joinNamed_IgnoresEmptyNames(t *testing.T) {
+	input := []namedRef{
+		{Name: "Action"},
+		{Name: ""},
+		{Name: "Adventure"},
+	}
+
+	got := joinNamed(input)
+	want := "Action, Adventure"
+	if got != want {
+		t.Errorf("joinNamed = %q; want %q", got, want)
+	}
+}
+
+func Test_escapeSearchQuery_EscapesControlCharacters(t *testing.T) {
+	got := escapeSearchQuery("zelda\\\";\nlimit 500")
+	want := `zelda\\\"; limit 500`
+	if got != want {
+		t.Errorf("escapeSearchQuery = %q; want %q", got, want)
+	}
+}
+
+func Test_pickDescription_PrefersSummary(t *testing.T) {
+	if got := pickDescription("summary", "storyline"); got != "summary" {
+		t.Errorf("expected summary preferred, got %q", got)
+	}
+	if got := pickDescription("", "storyline"); got != "storyline" {
+		t.Errorf("expected fallback to storyline, got %q", got)
+	}
+	if got := pickDescription("", ""); got != "" {
+		t.Errorf("expected empty, got %q", got)
+	}
+}
+
+func Test_roundTo_RoundsValue(t *testing.T) {
+	if got := roundTo(87.456, 1); got != 87.5 {
+		t.Errorf("roundTo(87.456, 1) = %v; want 87.5", got)
+	}
+	if got := roundTo(87.44, 1); got != 87.4 {
+		t.Errorf("roundTo(87.44, 1) = %v; want 87.4", got)
+	}
+}
+
+func Test_Plugin_MetadataValues(t *testing.T) {
+	p := New()
+
+	if p.ID() != "igdb_games" {
+		t.Errorf("ID = %q; want igdb_games", p.ID())
+	}
+	if p.CategoryName() != "Video Games" {
+		t.Errorf("CategoryName = %q; want Video Games", p.CategoryName())
+	}
+
+	if len(p.SearchFields()) == 0 {
+		t.Error("expected at least one search field")
+	}
+
+	attrs := p.Attributes()
+	if len(attrs) == 0 {
+		t.Fatal("expected attributes to be defined")
+	}
+
+	// Sanity check: every attribute uses the games.* namespace.
+	for _, a := range attrs {
+		if len(a.Key) < len("games.") || a.Key[:len("games.")] != "games." {
+			t.Errorf("attribute %q is not in the games.* namespace", a.Key)
+		}
+	}
+}
+
+func Test_Plugin_DisabledWhenCredentialsMissing(t *testing.T) {
+	t.Setenv(clientIDEnvVar, "")
+	t.Setenv(clientSecretEnvVar, "")
+	ClientID, ClientSecret = "", ""
+
+	p := New()
+	if p.Enabled() {
+		t.Error("plugin should be disabled without credentials")
+	}
+	reason := p.DisabledReason()
+	if reason == "" {
+		t.Error("expected disabled reason when credentials missing")
+	}
+}
+
+func Test_Plugin_EnabledWithEnvCredentials(t *testing.T) {
+	t.Setenv(clientIDEnvVar, "fake-id")
+	t.Setenv(clientSecretEnvVar, "fake-secret")
+
+	p := New()
+	if !p.Enabled() {
+		t.Errorf("plugin should be enabled with credentials, got reason: %s", p.DisabledReason())
+	}
+}
+
+func Test_Fetch_UsesCurrentIGDBFieldsAndMapsResponse(t *testing.T) {
+	t.Setenv(clientIDEnvVar, "fake-id")
+	t.Setenv(clientSecretEnvVar, "fake-secret")
+
+	p := New()
+	p.tokens.httpClient.Transport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if req.URL.Host != "id.twitch.tv" {
+			t.Fatalf("unexpected token host %q", req.URL.Host)
+		}
+		if req.URL.Query().Get("grant_type") != "client_credentials" {
+			t.Errorf("unexpected grant_type %q", req.URL.Query().Get("grant_type"))
+		}
+		return response(http.StatusOK, `{"access_token":"token","expires_in":3600,"token_type":"bearer"}`), nil
+	})
+	p.httpClient.Transport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if got := req.Header.Get("Client-ID"); got != "fake-id" {
+			t.Errorf("Client-ID = %q; want fake-id", got)
+		}
+		if got := req.Header.Get("Authorization"); got != "Bearer token" {
+			t.Errorf("Authorization = %q; want Bearer token", got)
+		}
+		body, err := io.ReadAll(req.Body)
+		if err != nil {
+			t.Fatal(err)
+		}
+		query := string(body)
+		for _, field := range []string{
+			"game_type.type",
+			"game_status.status",
+			"age_ratings.organization.name",
+			"age_ratings.rating_category.rating",
+		} {
+			if !strings.Contains(query, field) {
+				t.Errorf("query does not contain current IGDB field %q: %s", field, query)
+			}
+		}
+		return response(http.StatusOK, `[{
+			"id":7346,
+			"name":"The Legend of Zelda: Breath of the Wild",
+			"summary":"An adventure.",
+			"first_release_date":1488499200,
+			"platforms":[{"id":130,"name":"Nintendo Switch"}],
+			"release_dates":[{"platform":130,"date":1488499200}],
+			"age_ratings":[{"organization":{"name":"ESRB"},"rating_category":{"rating":"E10+"}}],
+			"game_type":{"type":"Main Game"},
+			"game_status":{"status":"Released"},
+			"rating":91.24
+		}]`), nil
+	})
+
+	data, err := p.Fetch(context.Background(), "7346:130")
+	if err != nil {
+		t.Fatalf("Fetch returned error: %v", err)
+	}
+	if data.Name != "The Legend of Zelda: Breath of the Wild" {
+		t.Errorf("name = %q", data.Name)
+	}
+	checks := map[string]any{
+		"games.platform":      "Nintendo Switch",
+		"games.release_date":  "2017-03-03",
+		"games.year_released": 2017,
+		"games.age_rating":    "ESRB: E10+",
+		"games.category":      "Main Game",
+		"games.status":        "Released",
+		"games.rating":        91.2,
+	}
+	for key, want := range checks {
+		if got := data.Attributes[key]; got != want {
+			t.Errorf("attribute %s = %#v; want %#v", key, got, want)
+		}
+	}
+}

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,6 +1,6 @@
 # This file starts development dependencies. The backend runs on the host and
 # reads plugin credentials from its environment, for example:
-#   ATTIC_GOOGLE_BOOKS_API_KEY=... ATTIC_TMDB_API_KEY=... make dev
+#   ATTIC_IGDB_CLIENT_ID=... ATTIC_IGDB_CLIENT_SECRET=... make dev
 services:
   postgres:
     image: postgres:16-alpine

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,6 +30,8 @@ services:
       - ATTIC_GOOGLE_BOOKS_API_KEY=${ATTIC_GOOGLE_BOOKS_API_KEY:-}
       - ATTIC_TMDB_API_KEY=${ATTIC_TMDB_API_KEY:-}
       - ATTIC_BGG_API_KEY=${ATTIC_BGG_API_KEY:-}
+      - ATTIC_IGDB_CLIENT_ID=${ATTIC_IGDB_CLIENT_ID:-}
+      - ATTIC_IGDB_CLIENT_SECRET=${ATTIC_IGDB_CLIENT_SECRET:-}
     volumes:
       - attic_uploads:/data/uploads
     depends_on:

--- a/rfcs/008-igdb-plugin.md
+++ b/rfcs/008-igdb-plugin.md
@@ -1,0 +1,306 @@
+# RFC 008: IGDB Plugin
+
+> **Status**: Implemented
+> **Created**: 2026-09-06
+> **Author**: @lmmendes
+
+---
+
+## Summary
+
+The IGDB plugin enables users to import video games from the [Internet Game Database (IGDB)](https://www.igdb.com/api). It automatically creates and manages a "Video Games" category with namespaced attributes for game metadata, and lets users pick the specific platform release (PS5, Xbox, PC, etc.) that matches their physical or digital copy.
+
+---
+
+## Plugin Details
+
+| Property | Value |
+|----------|-------|
+| **Plugin ID** | `igdb_games` |
+| **Display Name** | IGDB |
+| **Category** | Video Games |
+| **API** | IGDB REST API v4 |
+| **Base URL** | `https://api.igdb.com/v4` |
+| **Authentication** | Twitch OAuth (Client-ID + Bearer token) |
+
+---
+
+## Authentication
+
+Unlike the other plugins (which use a single bearer token), IGDB is owned by Twitch and requires Twitch app credentials. The plugin needs **two** values:
+
+| Environment variable | Description |
+|---|---|
+| `ATTIC_IGDB_CLIENT_ID` | Twitch application Client-ID |
+| `ATTIC_IGDB_CLIENT_SECRET` | Twitch application Client Secret |
+
+Build-time injection is also supported:
+```
+-ldflags="-X github.com/lmmendes/attic/internal/plugin/igdb.ClientID=... \
+          -X github.com/lmmendes/attic/internal/plugin/igdb.ClientSecret=..."
+```
+
+### Token lifecycle
+
+The plugin exchanges the credentials for a Bearer token via:
+```
+POST https://id.twitch.tv/oauth2/token?client_id=...&client_secret=...&grant_type=client_credentials
+```
+
+Tokens are cached in memory (per-process) and refreshed automatically:
+- Before any request that would land inside a 5-minute leeway of expiry.
+- After receiving a `401 Unauthorized` from the IGDB API (token revoked / rotated). The plugin invalidates the cache and retries the request **once** with a fresh token.
+
+### Obtaining credentials
+
+1. Register an application at https://dev.twitch.tv/console/apps.
+2. Choose any OAuth Redirect URL (it isn't used; client-credentials flow doesn't require redirect).
+3. Copy the generated Client-ID + Client Secret into the environment variables above.
+
+---
+
+## Category & Attributes
+
+The plugin manages a single category called **Video Games**, with all attributes namespaced under `games.*`:
+
+| Key | Display Name | Data Type | Required |
+|-----|--------------|-----------|----------|
+| `games.platform` | Platform | string | No |
+| `games.release_date` | Release Date | date | No |
+| `games.year_released` | Year Released | number | No |
+| `games.genres` | Genres | string | No |
+| `games.themes` | Themes | string | No |
+| `games.developers` | Developers | string | No |
+| `games.publishers` | Publishers | string | No |
+| `games.game_modes` | Game Modes | string | No |
+| `games.player_perspectives` | Player Perspective | string | No |
+| `games.franchise` | Franchise | string | No |
+| `games.engine` | Game Engine | string | No |
+| `games.age_rating` | Age Rating | string | No |
+| `games.category` | Edition Type | string | No |
+| `games.status` | Release Status | string | No |
+| `games.rating` | IGDB Rating | number | No |
+| `games.url` | IGDB URL | string | No |
+
+`games.platform` is **singular** — each imported asset represents a single platform release.
+
+---
+
+## Search Fields
+
+| Field Key | Label | API Mapping |
+|-----------|-------|-------------|
+| `name` | Name | Apicalypse `search "<query>";` |
+
+---
+
+## Platform Selection via Composite External IDs
+
+A game like *Cyberpunk 2077* exists on PS5, Xbox Series X, PC, etc., and each platform release is effectively a different asset in a collection. To let the user pick the right one **without** changing the `ImportPlugin` interface (which only accepts `external_id`), the plugin uses a composite external ID:
+
+```
+<game_id>:<platform_id>
+```
+
+| Step | Behavior |
+|---|---|
+| **Search** | One row per `(game, platform)` combination. Capped at 6 platforms per game, sorted by release date descending. Subtitle is rendered as `Platform Name (Year)`. |
+| **Fetch** | The composite ID is parsed back. The plugin selects the platform-specific release date when available, and writes the platform name into `games.platform`. |
+
+Games with no platform metadata fall back to a single search row with just `<game_id>` as the external ID.
+
+### Why cap at 6 platforms?
+
+Some games (e.g. Tetris) have 50+ platform releases. Without a cap, search results become unusable. We surface the 6 most recent releases — typically the platforms users actually own physical/digital copies for.
+
+---
+
+## API Integration
+
+### Authentication query
+
+All API requests include:
+```
+Client-ID: <client_id>
+Authorization: Bearer <access_token>
+Accept: application/json
+Content-Type: text/plain
+```
+
+### Search
+
+```
+POST /games
+search "<query>";
+fields name, first_release_date, cover.image_id,
+       platforms.id, platforms.name,
+       release_dates.platform, release_dates.date;
+limit 10;
+```
+
+### Fetch
+
+```
+POST /games
+fields name, summary, storyline, first_release_date, cover.image_id,
+       platforms.name, genres.name, themes.name,
+       game_modes.name, player_perspectives.name,
+       involved_companies.developer, involved_companies.publisher, involved_companies.company.name,
+       rating, age_ratings.organization.name, age_ratings.rating_category.rating,
+       franchises.name, game_engines.name,
+       game_status.status, game_type.type, url,
+       release_dates.platform, release_dates.date;
+where id = <game_id>;
+limit 1;
+```
+
+---
+
+## Implementation Details
+
+### Apicalypse Query Format
+
+IGDB uses its custom **Apicalypse** query language (sent as the POST body, content-type `text/plain`). The plugin builds these queries as plain strings rather than using a generated query builder — the surface area is small enough that this is simpler and easier to read.
+
+### Image URLs
+
+IGDB cover URLs follow the pattern:
+```
+https://images.igdb.com/igdb/image/upload/<size>/<image_id>.jpg
+```
+
+The plugin uses:
+- `t_cover_small` for search thumbnails
+- `t_cover_big` for the imported asset image (downloaded and stored by the existing import handler)
+
+### Date Handling
+
+IGDB returns dates as Unix timestamps. The plugin converts them to UTC `YYYY-MM-DD` strings (compatible with the `date` attribute type) and additionally extracts the year as a numeric `games.year_released` attribute for easy filtering.
+
+### Description Selection
+
+`summary` is preferred over `storyline` because the latter often contains plot spoilers.
+
+### Reference Mapping
+
+IGDB's current schema exposes game type, game status, age-rating organization, and age-rating category as reference objects. The plugin expands those references (`game_type.type`, `game_status.status`, `age_ratings.organization.name`, and `age_ratings.rating_category.rating`) and stores their human-readable values. This avoids the deprecated `category`, `status`, and numeric age-rating enum fields used by the original reference branch.
+
+### Rate Limiting
+
+IGDB allows ~4 requests/sec. The plugin enforces a 250 ms minimum between requests via a mutex-guarded timestamp.
+
+---
+
+## Example Usage
+
+### Search for Games
+
+```
+GET /api/plugins/igdb_games/search?field=name&q=zelda+breath&limit=10
+```
+
+**Response:**
+```json
+{
+  "results": [
+    {
+      "external_id": "7346:130",
+      "title": "The Legend of Zelda: Breath of the Wild",
+      "subtitle": "Nintendo Switch (2017)",
+      "image_url": "https://images.igdb.com/igdb/image/upload/t_cover_small/co3p2d.jpg"
+    },
+    {
+      "external_id": "7346:41",
+      "title": "The Legend of Zelda: Breath of the Wild",
+      "subtitle": "Wii U (2017)",
+      "image_url": "https://images.igdb.com/igdb/image/upload/t_cover_small/co3p2d.jpg"
+    }
+  ]
+}
+```
+
+### Import a Game
+
+```
+POST /api/plugins/igdb_games/import
+{
+  "external_id": "7346:130"
+}
+```
+
+**Response:**
+```json
+{
+  "asset": {
+    "id": "uuid-of-created-asset",
+    "name": "The Legend of Zelda: Breath of the Wild",
+    "category_id": "uuid-of-video-games-category",
+    "attributes": {
+      "games.platform": "Nintendo Switch",
+      "games.release_date": "2017-03-03",
+      "games.year_released": 2017,
+      "games.genres": "Role-playing (RPG), Adventure",
+      "games.themes": "Action, Fantasy, Open world",
+      "games.developers": "Nintendo EPD",
+      "games.publishers": "Nintendo",
+      "games.game_modes": "Single player",
+      "games.player_perspectives": "Third person",
+      "games.franchise": "The Legend of Zelda",
+      "games.engine": "Havok",
+      "games.age_rating": "ESRB: E10+, PEGI: 12",
+      "games.category": "Main Game",
+      "games.status": "Released",
+      "games.rating": 91.2,
+      "games.url": "https://www.igdb.com/games/the-legend-of-zelda-breath-of-the-wild"
+    },
+    "import_plugin_id": "igdb_games",
+    "import_external_id": "7346:130"
+  }
+}
+```
+
+---
+
+## Rate Limits
+
+IGDB documents the following limits:
+- ~4 requests/sec per IP
+- Excessive requests return HTTP 429
+
+The plugin enforces this from the client side with a 250 ms minimum interval between requests.
+
+---
+
+## Security Considerations
+
+1. **Credentials**: Both Client-ID and Client Secret are read from environment variables (preferred) or build-time injection. The Client Secret is the more sensitive value — treat it like an API key.
+2. **Token Caching**: Tokens are kept in memory only. They are never persisted to disk or logs.
+3. **Input Validation**: External IDs are parsed defensively (positive integer game ID, optional positive integer platform ID).
+4. **Image Downloads**: Cover images are downloaded and stored by the existing import handler, not hot-linked.
+
+---
+
+## Files
+
+| File | Description |
+|------|-------------|
+| `backend/internal/plugin/igdb/auth.go` | Twitch OAuth client-credentials token management |
+| `backend/internal/plugin/igdb/igdb.go` | Plugin implementation (search, fetch, mapping) |
+| `backend/internal/plugin/igdb/igdb_test.go` | Unit tests for pure helpers |
+
+---
+
+## Future Work
+
+- **Multiple language support**: IGDB supports localised game info via `language_supports` and `alternative_names` — could be a future opt-in field.
+- **Screenshots & artwork**: Currently only the cover is imported. A future enhancement could attach additional screenshots as asset attachments.
+- **Refresh / re-sync**: Re-fetch existing imported assets to pick up updated ratings or status changes.
+
+---
+
+## Related RFCs
+
+- [RFC 001: Import Plugins](./001-import-plugins.md) – Plugin system architecture
+- [RFC 002: Google Books Plugin](./002-google-books-plugin.md)
+- [RFC 003: TMDB Plugin](./003-tmdb-plugin.md)
+- [RFC 007: BGG Plugin](./007-bgg-plugin.md)


### PR DESCRIPTION
## Summary

  Adds an IGDB video game import plugin with Twitch OAuth authentication and platform-aware game
  imports.

## Changes

- Add RFC 008 documenting the IGDB plugin design and API integration.
- Add Twitch client-credentials token management with in-memory caching.
- Add automatic token refresh and retry on IGDB `401 Unauthorized` responses.
- Implement IGDB game search and metadata fetching.
- Support platform-specific composite external IDs (`game_id:platform_id`).
- Import covers, descriptions, release dates, ratings, genres, themes, companies, game modes, perspectives, status, and game type.
- Use IGDB’s current replacement fields instead of deprecated enum fields.
- Register the plugin with the backend.
- Add environment and Docker Compose configuration for:
     - `ATTIC_IGDB_CLIENT_ID`
     - `ATTIC_IGDB_CLIENT_SECRET`
- Add unit and HTTP mapping tests.
- Update README integration documentation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added IGDB video game search and import support.
  * Imported games include platforms, release dates, descriptions, images, ratings, companies, genres, and other metadata.
  * Added secure Twitch authentication with automatic token handling and retry support.
  * Added optional configuration for IGDB client credentials.

* **Documentation**
  * Updated Smart Integrations documentation for TMDB and IGDB.
  * Added setup guidance, authentication details, configuration examples, and IGDB usage documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->