### PR TITLE
feat(categories): restore hierarchical inheritance

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Attic mirrors the way a home is organized with nested locations such as rooms, s
 
 **Home Inventory**
 - Full CRUD with custom attributes per category (strings, numbers, booleans, dates, dropdowns)
-- Hierarchical categories and locations that mirror real-world spaces
+- Hierarchical categories and locations; child categories inherit their ancestors' custom fields
 - Condition tracking (new, used, damaged, or custom states)
 - Warranty expiration monitoring on the dashboard
 - File attachments for invoices, manuals, and photos
@@ -20,6 +20,7 @@ Attic mirrors the way a home is organized with nested locations such as rooms, s
 **Search & Discovery**
 - Full-text search across asset names and descriptions
 - Filter by category, location, and condition
+- Category filters include assets assigned to descendant categories
 
 **Smart Integrations**
 - Automated imports from Google Books, TMDB (movies and TV), BoardGameGeek, and IGDB (video games)

--- a/backend/cmd/server/openapi.yaml
+++ b/backend/cmd/server/openapi.yaml
@@ -111,6 +111,12 @@ paths:
         - sessionCookie: []
       parameters:
         - $ref: '#/components/parameters/id'
+        - name: inherited
+          in: query
+          description: Include the effective attribute schema inherited from ancestor categories
+          schema:
+            type: boolean
+            default: false
       responses:
         '200':
           description: Category details
@@ -423,7 +429,7 @@ paths:
             format: uuid
         - name: category_id
           in: query
-          description: Filter by a category UUID or use `uncategorized` for assets without a category
+          description: Filter by a category UUID (including its descendants) or use `uncategorized` for assets without a category
           schema:
             oneOf:
               - type: string

--- a/backend/internal/domain/models.go
+++ b/backend/internal/domain/models.go
@@ -112,6 +112,7 @@ type CategoryAttribute struct {
 	Required    bool      `json:"required"`
 	SortOrder   int       `json:"sort_order"`
 	CreatedAt   time.Time `json:"created_at"`
+	Inherited   bool      `json:"inherited,omitempty"`
 
 	// Populated by queries
 	Attribute *Attribute `json:"attribute,omitempty"`

--- a/backend/internal/domain/repository.go
+++ b/backend/internal/domain/repository.go
@@ -36,8 +36,10 @@ type ConditionRepository interface {
 type CategoryRepository interface {
 	GetByID(ctx context.Context, id uuid.UUID) (*Category, error)
 	GetByIDWithAttributes(ctx context.Context, id uuid.UUID) (*Category, error)
+	GetByIDWithInheritedAttributes(ctx context.Context, orgID, id uuid.UUID) (*Category, error)
 	List(ctx context.Context, orgID uuid.UUID) ([]Category, error)
 	ListTree(ctx context.Context, orgID uuid.UUID) ([]Category, error)
+	ValidateParent(ctx context.Context, orgID, categoryID, parentID uuid.UUID) (bool, error)
 	Create(ctx context.Context, cat *Category) error
 	Update(ctx context.Context, cat *Category) error
 	Delete(ctx context.Context, id uuid.UUID) error

--- a/backend/internal/handler/asset.go
+++ b/backend/internal/handler/asset.go
@@ -1,10 +1,13 @@
 package handler
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -185,6 +188,13 @@ func (h *Handler) CreateAsset(w http.ResponseWriter, r *http.Request) {
 		}
 		categoryID = &id
 	}
+	if message, err := h.validateAssetCategory(r.Context(), categoryID, req.Attributes); err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to validate category attributes")
+		return
+	} else if message != "" {
+		writeError(w, http.StatusBadRequest, message)
+		return
+	}
 
 	asset := &domain.Asset{
 		OrganizationID: h.orgID,
@@ -275,6 +285,13 @@ func (h *Handler) UpdateAsset(w http.ResponseWriter, r *http.Request) {
 		}
 		categoryID = &id
 	}
+	if message, err := h.validateAssetCategory(r.Context(), categoryID, req.Attributes); err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to validate category attributes")
+		return
+	} else if message != "" {
+		writeError(w, http.StatusBadRequest, message)
+		return
+	}
 
 	asset.CategoryID = categoryID
 	asset.Name = req.Name
@@ -333,6 +350,51 @@ func (h *Handler) UpdateAsset(w http.ResponseWriter, r *http.Request) {
 	}
 
 	writeJSON(w, http.StatusOK, asset)
+}
+
+func (h *Handler) validateAssetCategory(ctx context.Context, categoryID *uuid.UUID, rawAttributes json.RawMessage) (string, error) {
+	if categoryID == nil {
+		return "", nil
+	}
+	category, err := h.repos.Categories.GetByIDWithInheritedAttributes(ctx, h.orgID, *categoryID)
+	if err != nil {
+		return "", err
+	}
+	if category == nil {
+		return "category does not exist in this workspace", nil
+	}
+	missing, err := missingRequiredCategoryAttributes(category, rawAttributes)
+	if err != nil {
+		return "attributes must be a JSON object", nil
+	}
+	if len(missing) > 0 {
+		return fmt.Sprintf("required category attributes are missing: %s", strings.Join(missing, ", ")), nil
+	}
+	return "", nil
+}
+
+func missingRequiredCategoryAttributes(category *domain.Category, rawAttributes json.RawMessage) ([]string, error) {
+	values := make(map[string]any)
+	if len(rawAttributes) > 0 && string(rawAttributes) != "null" {
+		if err := json.Unmarshal(rawAttributes, &values); err != nil {
+			return nil, err
+		}
+	}
+	missing := make([]string, 0)
+	for _, assignment := range category.Attributes {
+		if !assignment.Required || assignment.Attribute == nil {
+			continue
+		}
+		value, ok := values[assignment.Attribute.Key]
+		if !ok || value == nil {
+			missing = append(missing, assignment.Attribute.Name)
+			continue
+		}
+		if text, ok := value.(string); ok && strings.TrimSpace(text) == "" {
+			missing = append(missing, assignment.Attribute.Name)
+		}
+	}
+	return missing, nil
 }
 
 func (h *Handler) DeleteAsset(w http.ResponseWriter, r *http.Request) {

--- a/backend/internal/handler/asset_test.go
+++ b/backend/internal/handler/asset_test.go
@@ -701,6 +701,29 @@ func Test_UpdateAsset_MissingCategoryID_ClearsCategoryAndAttributes(t *testing.T
 	}
 }
 
+func Test_MissingRequiredCategoryAttributes_IncludesInheritedFields(t *testing.T) {
+	category := &domain.Category{Attributes: []domain.CategoryAttribute{
+		{
+			Required:  true,
+			Inherited: true,
+			Attribute: &domain.Attribute{Name: "Vendor", Key: "vendor", DataType: domain.AttributeTypeString},
+		},
+		{
+			Required:  true,
+			Inherited: true,
+			Attribute: &domain.Attribute{Name: "Refurbished", Key: "refurbished", DataType: domain.AttributeTypeBoolean},
+		},
+	}}
+
+	missing, err := missingRequiredCategoryAttributes(category, json.RawMessage(`{"vendor":"  ","refurbished":false}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(missing) != 1 || missing[0] != "Vendor" {
+		t.Fatalf("missing attributes = %v; want [Vendor]", missing)
+	}
+}
+
 func Test_UpdateAsset_NonExistentAsset_ReturnsNotFound(t *testing.T) {
 	h := newTestAssetHandler()
 	nonExistentID := uuid.New()

--- a/backend/internal/handler/category.go
+++ b/backend/internal/handler/category.go
@@ -70,7 +70,15 @@ func (h *Handler) GetCategory(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	cat, err := h.repos.Categories.GetByIDWithAttributes(r.Context(), id)
+	var cat *domain.Category
+	if r.URL.Query().Get("inherited") == "true" {
+		cat, err = h.repos.Categories.GetByIDWithInheritedAttributes(r.Context(), h.orgID, id)
+	} else {
+		cat, err = h.repos.Categories.GetByIDWithAttributes(r.Context(), id)
+		if cat != nil && cat.OrganizationID != h.orgID {
+			cat = nil
+		}
+	}
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "failed to get category")
 		return
@@ -106,6 +114,15 @@ func (h *Handler) CreateCategory(w http.ResponseWriter, r *http.Request) {
 		parentID, err := parseUUIDString(*req.ParentID)
 		if err != nil {
 			writeError(w, http.StatusBadRequest, "invalid parent_id")
+			return
+		}
+		valid, err := h.repos.Categories.ValidateParent(r.Context(), h.orgID, uuid.Nil, parentID)
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, "failed to validate parent category")
+			return
+		}
+		if !valid {
+			writeError(w, http.StatusBadRequest, "parent category must belong to this workspace")
 			return
 		}
 		cat.ParentID = &parentID
@@ -157,7 +174,7 @@ func (h *Handler) UpdateCategory(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusInternalServerError, "failed to get category")
 		return
 	}
-	if cat == nil {
+	if cat == nil || cat.OrganizationID != h.orgID {
 		writeError(w, http.StatusNotFound, "category not found")
 		return
 	}
@@ -170,6 +187,15 @@ func (h *Handler) UpdateCategory(w http.ResponseWriter, r *http.Request) {
 		parentID, err := parseUUIDString(*req.ParentID)
 		if err != nil {
 			writeError(w, http.StatusBadRequest, "invalid parent_id")
+			return
+		}
+		valid, err := h.repos.Categories.ValidateParent(r.Context(), h.orgID, cat.ID, parentID)
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, "failed to validate parent category")
+			return
+		}
+		if !valid {
+			writeError(w, http.StatusBadRequest, "parent category cannot be itself, a descendant, or outside this workspace")
 			return
 		}
 		cat.ParentID = &parentID
@@ -216,7 +242,7 @@ func (h *Handler) DeleteCategory(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusInternalServerError, "failed to get category")
 		return
 	}
-	if cat == nil {
+	if cat == nil || cat.OrganizationID != h.orgID {
 		writeError(w, http.StatusNotFound, "category not found")
 		return
 	}

--- a/backend/internal/repository/asset.go
+++ b/backend/internal/repository/asset.go
@@ -144,7 +144,17 @@ func (r *AssetRepository) List(ctx context.Context, orgID uuid.UUID, filter doma
 	if filter.Uncategorized {
 		conditions = append(conditions, "a.category_id IS NULL")
 	} else if filter.CategoryID != nil {
-		conditions = append(conditions, fmt.Sprintf("a.category_id = $%d", argNum))
+		conditions = append(conditions, fmt.Sprintf(`EXISTS (
+			WITH RECURSIVE descendants AS (
+				SELECT id FROM categories
+				WHERE id = $%d AND organization_id = a.organization_id AND deleted_at IS NULL
+				UNION
+				SELECT child.id FROM categories child
+				JOIN descendants parent ON child.parent_id = parent.id
+				WHERE child.organization_id = a.organization_id AND child.deleted_at IS NULL
+			)
+			SELECT 1 FROM descendants WHERE descendants.id = a.category_id
+		)`, argNum))
 		args = append(args, *filter.CategoryID)
 		argNum++
 	}

--- a/backend/internal/repository/asset_test.go
+++ b/backend/internal/repository/asset_test.go
@@ -260,10 +260,12 @@ func Test_AssetRepository_List_FilterByCategory(t *testing.T) {
 	org, _ := fixtures.CreateOrganization(ctx, "Test Org")
 	cat1, _ := fixtures.CreateCategory(ctx, org.ID, "Electronics", nil)
 	cat2, _ := fixtures.CreateCategory(ctx, org.ID, "Books", nil)
+	child, _ := fixtures.CreateCategory(ctx, org.ID, "Phones", &cat1.ID)
 
 	fixtures.CreateAsset(ctx, org.ID, cat1.ID, "Phone")
 	fixtures.CreateAsset(ctx, org.ID, cat1.ID, "Laptop")
 	fixtures.CreateAsset(ctx, org.ID, cat2.ID, "Book")
+	fixtures.CreateAsset(ctx, org.ID, child.ID, "Smartphone")
 
 	repo := NewAssetRepository(testDB.Pool)
 	assets, total, err := repo.List(ctx, org.ID, domain.AssetFilter{CategoryID: &cat1.ID}, domain.Pagination{Limit: 100})
@@ -271,11 +273,11 @@ func Test_AssetRepository_List_FilterByCategory(t *testing.T) {
 		t.Fatalf("failed to list: %v", err)
 	}
 
-	if total != 2 {
-		t.Errorf("expected 2 assets in Electronics, got %d", total)
+	if total != 3 {
+		t.Errorf("expected 3 assets in Electronics and descendants, got %d", total)
 	}
-	if len(assets) != 2 {
-		t.Errorf("expected 2 assets, got %d", len(assets))
+	if len(assets) != 3 {
+		t.Errorf("expected 3 assets, got %d", len(assets))
 	}
 }
 

--- a/backend/internal/repository/category.go
+++ b/backend/internal/repository/category.go
@@ -53,6 +53,84 @@ func (r *CategoryRepository) GetByIDWithAttributes(ctx context.Context, id uuid.
 	return cat, nil
 }
 
+// GetByIDWithInheritedAttributes returns the effective attribute schema for a
+// category. Attributes are ordered from the root category to the selected
+// category. If an attribute is assigned more than once in the ancestry, the
+// closest assignment supplies its required and sort-order settings.
+func (r *CategoryRepository) GetByIDWithInheritedAttributes(ctx context.Context, orgID, id uuid.UUID) (*domain.Category, error) {
+	cat, err := r.GetByID(ctx, id)
+	if err != nil || cat == nil {
+		return cat, err
+	}
+	if cat.OrganizationID != orgID {
+		return nil, nil
+	}
+
+	rows, err := r.pool.Query(ctx, `
+		WITH RECURSIVE ancestry AS (
+			SELECT id, parent_id, 0 AS depth, ARRAY[id] AS path
+			FROM categories
+			WHERE id = $1 AND organization_id = $2 AND deleted_at IS NULL
+			UNION ALL
+			SELECT parent.id, parent.parent_id, ancestry.depth + 1, ancestry.path || parent.id
+			FROM categories parent
+			JOIN ancestry ON parent.id = ancestry.parent_id
+			WHERE parent.organization_id = $2
+			  AND parent.deleted_at IS NULL
+			  AND NOT parent.id = ANY(ancestry.path)
+		)
+		SELECT ancestry.depth,
+		       ca.id, ca.category_id, ca.attribute_id, ca.required, ca.sort_order, ca.created_at,
+		       a.id, a.organization_id, a.plugin_id, a.name, a.key, a.data_type, a.created_at, a.updated_at
+		FROM ancestry
+		JOIN category_attributes ca ON ca.category_id = ancestry.id
+		JOIN attributes a ON a.id = ca.attribute_id AND a.deleted_at IS NULL
+		WHERE a.organization_id = $2
+		ORDER BY ancestry.depth DESC, ca.sort_order, lower(a.name), a.id
+	`, id, orgID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	type candidate struct {
+		depth     int
+		attribute domain.CategoryAttribute
+	}
+	candidates := make([]candidate, 0)
+	closestDepth := make(map[uuid.UUID]int)
+	for rows.Next() {
+		var depth int
+		var categoryAttribute domain.CategoryAttribute
+		var attribute domain.Attribute
+		if err := rows.Scan(
+			&depth,
+			&categoryAttribute.ID, &categoryAttribute.CategoryID, &categoryAttribute.AttributeID,
+			&categoryAttribute.Required, &categoryAttribute.SortOrder, &categoryAttribute.CreatedAt,
+			&attribute.ID, &attribute.OrganizationID, &attribute.PluginID, &attribute.Name,
+			&attribute.Key, &attribute.DataType, &attribute.CreatedAt, &attribute.UpdatedAt,
+		); err != nil {
+			return nil, err
+		}
+		categoryAttribute.Attribute = &attribute
+		categoryAttribute.Inherited = depth > 0
+		candidates = append(candidates, candidate{depth: depth, attribute: categoryAttribute})
+		if previous, ok := closestDepth[categoryAttribute.AttributeID]; !ok || depth < previous {
+			closestDepth[categoryAttribute.AttributeID] = depth
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	for _, item := range candidates {
+		if item.depth == closestDepth[item.attribute.AttributeID] {
+			cat.Attributes = append(cat.Attributes, item.attribute)
+		}
+	}
+	return cat, nil
+}
+
 func (r *CategoryRepository) List(ctx context.Context, orgID uuid.UUID) ([]domain.Category, error) {
 	query := `
 		SELECT id, organization_id, parent_id, plugin_id, name, description, icon, created_at, updated_at
@@ -108,21 +186,68 @@ func (r *CategoryRepository) ListTree(ctx context.Context, orgID uuid.UUID) ([]d
 }
 
 func buildCategoryTree(categories []domain.Category) []domain.Category {
-	byID := make(map[uuid.UUID]*domain.Category)
+	byID := make(map[uuid.UUID]*domain.Category, len(categories))
 	for i := range categories {
 		byID[categories[i].ID] = &categories[i]
 	}
 
-	var roots []domain.Category
+	childrenByParent := make(map[uuid.UUID][]*domain.Category)
+	roots := make([]*domain.Category, 0)
 	for i := range categories {
 		cat := &categories[i]
-		if cat.ParentID == nil {
-			roots = append(roots, *cat)
-		} else if parent, ok := byID[*cat.ParentID]; ok {
-			parent.Children = append(parent.Children, *cat)
+		if cat.ParentID == nil || byID[*cat.ParentID] == nil {
+			roots = append(roots, cat)
+		} else {
+			childrenByParent[*cat.ParentID] = append(childrenByParent[*cat.ParentID], cat)
 		}
 	}
-	return roots
+
+	var build func(*domain.Category, map[uuid.UUID]bool) domain.Category
+	build = func(cat *domain.Category, path map[uuid.UUID]bool) domain.Category {
+		result := *cat
+		result.Children = nil
+		if path[cat.ID] {
+			return result
+		}
+		nextPath := make(map[uuid.UUID]bool, len(path)+1)
+		for id := range path {
+			nextPath[id] = true
+		}
+		nextPath[cat.ID] = true
+		for _, child := range childrenByParent[cat.ID] {
+			result.Children = append(result.Children, build(child, nextPath))
+		}
+		return result
+	}
+
+	result := make([]domain.Category, 0, len(roots))
+	for _, root := range roots {
+		result = append(result, build(root, nil))
+	}
+	return result
+}
+
+// ValidateParent checks that a proposed parent belongs to the same organization
+// and is not the category itself or one of its descendants.
+func (r *CategoryRepository) ValidateParent(ctx context.Context, orgID, categoryID, parentID uuid.UUID) (bool, error) {
+	var valid bool
+	err := r.pool.QueryRow(ctx, `
+		WITH RECURSIVE ancestors AS (
+			SELECT id, parent_id, ARRAY[id] AS path
+			FROM categories
+			WHERE id = $2 AND organization_id = $1 AND deleted_at IS NULL
+			UNION ALL
+			SELECT parent.id, parent.parent_id, ancestors.path || parent.id
+			FROM categories parent
+			JOIN ancestors ON parent.id = ancestors.parent_id
+			WHERE parent.organization_id = $1
+			  AND parent.deleted_at IS NULL
+			  AND NOT parent.id = ANY(ancestors.path)
+		)
+		SELECT EXISTS (SELECT 1 FROM ancestors)
+		   AND NOT EXISTS (SELECT 1 FROM ancestors WHERE id = $3)
+	`, orgID, parentID, categoryID).Scan(&valid)
+	return valid, err
 }
 
 func (r *CategoryRepository) Create(ctx context.Context, c *domain.Category) error {
@@ -210,7 +335,17 @@ func (r *CategoryRepository) GetAssetCounts(ctx context.Context, orgID uuid.UUID
 	query := `
 		SELECT c.id::text, COUNT(a.id)
 		FROM categories c
-		LEFT JOIN assets a ON a.category_id = c.id AND a.deleted_at IS NULL
+		LEFT JOIN LATERAL (
+			WITH RECURSIVE descendants AS (
+				SELECT id FROM categories WHERE id = c.id
+				UNION
+				SELECT child.id FROM categories child
+				JOIN descendants parent ON child.parent_id = parent.id
+				WHERE child.organization_id = c.organization_id AND child.deleted_at IS NULL
+			)
+			SELECT id FROM descendants
+		) descendant ON TRUE
+		LEFT JOIN assets a ON a.category_id = descendant.id AND a.deleted_at IS NULL
 		WHERE c.organization_id = $1 AND c.deleted_at IS NULL
 		GROUP BY c.id
 	`

--- a/backend/internal/repository/category_test.go
+++ b/backend/internal/repository/category_test.go
@@ -211,6 +211,73 @@ func Test_CategoryRepository_GetByIDWithAttributes(t *testing.T) {
 	}
 }
 
+func Test_CategoryRepository_GetByIDWithInheritedAttributes(t *testing.T) {
+	ctx := context.Background()
+	if err := testDB.TruncateAll(ctx); err != nil {
+		t.Fatalf("failed to truncate: %v", err)
+	}
+
+	fixtures := testutil.NewFixtures(testDB.Pool)
+	org, _ := fixtures.CreateOrganization(ctx, "Test Org")
+	catRepo := NewCategoryRepository(testDB.Pool)
+	attrRepo := NewAttributeRepository(testDB.Pool)
+
+	root := &domain.Category{OrganizationID: org.ID, Name: "Hardware"}
+	if err := catRepo.Create(ctx, root); err != nil {
+		t.Fatal(err)
+	}
+	child := &domain.Category{OrganizationID: org.ID, ParentID: &root.ID, Name: "Displays"}
+	if err := catRepo.Create(ctx, child); err != nil {
+		t.Fatal(err)
+	}
+	leaf := &domain.Category{OrganizationID: org.ID, ParentID: &child.ID, Name: "Monitors"}
+	if err := catRepo.Create(ctx, leaf); err != nil {
+		t.Fatal(err)
+	}
+
+	attributes := []*domain.Attribute{
+		{OrganizationID: org.ID, Name: "Vendor", Key: "vendor", DataType: domain.AttributeTypeString},
+		{OrganizationID: org.ID, Name: "Connection", Key: "connection", DataType: domain.AttributeTypeString},
+		{OrganizationID: org.ID, Name: "Resolution", Key: "resolution", DataType: domain.AttributeTypeString},
+	}
+	for _, attribute := range attributes {
+		if err := attrRepo.Create(ctx, attribute); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := catRepo.SetAttributes(ctx, root.ID, []domain.CategoryAttributeAssignment{{AttributeID: attributes[0].ID, Required: true}}); err != nil {
+		t.Fatal(err)
+	}
+	if err := catRepo.SetAttributes(ctx, child.ID, []domain.CategoryAttributeAssignment{{AttributeID: attributes[1].ID}}); err != nil {
+		t.Fatal(err)
+	}
+	if err := catRepo.SetAttributes(ctx, leaf.ID, []domain.CategoryAttributeAssignment{{AttributeID: attributes[2].ID}}); err != nil {
+		t.Fatal(err)
+	}
+
+	fetched, err := catRepo.GetByIDWithInheritedAttributes(ctx, org.ID, leaf.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(fetched.Attributes) != 3 {
+		t.Fatalf("expected 3 effective attributes, got %d", len(fetched.Attributes))
+	}
+	got := []string{
+		fetched.Attributes[0].Attribute.Key,
+		fetched.Attributes[1].Attribute.Key,
+		fetched.Attributes[2].Attribute.Key,
+	}
+	want := []string{"vendor", "connection", "resolution"}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("attribute order = %v; want %v", got, want)
+		}
+	}
+	if !fetched.Attributes[0].Inherited || !fetched.Attributes[1].Inherited || fetched.Attributes[2].Inherited {
+		t.Fatalf("unexpected inherited flags: %#v", fetched.Attributes)
+	}
+}
+
 func Test_CategoryRepository_List_ReturnsCategoriesForOrg(t *testing.T) {
 	ctx := context.Background()
 	if err := testDB.TruncateAll(ctx); err != nil {
@@ -306,6 +373,8 @@ func Test_CategoryRepository_ListTree_ReturnsHierarchy(t *testing.T) {
 
 	laptops := &domain.Category{OrganizationID: org.ID, ParentID: &electronics.ID, Name: "Laptops"}
 	repo.Create(ctx, laptops)
+	ultrabooks := &domain.Category{OrganizationID: org.ID, ParentID: &laptops.ID, Name: "Ultrabooks"}
+	repo.Create(ctx, ultrabooks)
 
 	books := &domain.Category{OrganizationID: org.ID, Name: "Books"}
 	repo.Create(ctx, books)
@@ -317,6 +386,42 @@ func Test_CategoryRepository_ListTree_ReturnsHierarchy(t *testing.T) {
 
 	if len(tree) != 2 {
 		t.Errorf("expected 2 root categories, got %d", len(tree))
+	}
+	var electronicsNode *domain.Category
+	for i := range tree {
+		if tree[i].ID == electronics.ID {
+			electronicsNode = &tree[i]
+		}
+	}
+	if electronicsNode == nil || len(electronicsNode.Children) != 2 {
+		t.Fatalf("expected Electronics to have 2 children, got %#v", electronicsNode)
+	}
+	if electronicsNode.Children[0].ID != laptops.ID || len(electronicsNode.Children[0].Children) != 1 || electronicsNode.Children[0].Children[0].ID != ultrabooks.ID {
+		t.Fatalf("expected a complete three-level hierarchy, got %#v", electronicsNode.Children)
+	}
+}
+
+func Test_CategoryRepository_ValidateParentRejectsDescendantAndForeignCategory(t *testing.T) {
+	ctx := context.Background()
+	if err := testDB.TruncateAll(ctx); err != nil {
+		t.Fatalf("failed to truncate: %v", err)
+	}
+	fixtures := testutil.NewFixtures(testDB.Pool)
+	org, _ := fixtures.CreateOrganization(ctx, "Test Org")
+	otherOrg, _ := fixtures.CreateOrganization(ctx, "Other Org")
+	repo := NewCategoryRepository(testDB.Pool)
+	parent, _ := fixtures.CreateCategory(ctx, org.ID, "Parent", nil)
+	child, _ := fixtures.CreateCategory(ctx, org.ID, "Child", &parent.ID)
+	foreign, _ := fixtures.CreateCategory(ctx, otherOrg.ID, "Foreign", nil)
+
+	if valid, err := repo.ValidateParent(ctx, org.ID, child.ID, parent.ID); err != nil || !valid {
+		t.Fatalf("expected ancestor to be valid: valid=%v err=%v", valid, err)
+	}
+	if valid, err := repo.ValidateParent(ctx, org.ID, parent.ID, child.ID); err != nil || valid {
+		t.Fatalf("expected descendant to be invalid: valid=%v err=%v", valid, err)
+	}
+	if valid, err := repo.ValidateParent(ctx, org.ID, parent.ID, foreign.ID); err != nil || valid {
+		t.Fatalf("expected foreign category to be invalid: valid=%v err=%v", valid, err)
 	}
 }
 
@@ -435,11 +540,13 @@ func Test_CategoryRepository_GetAssetCounts(t *testing.T) {
 	org, _ := fixtures.CreateOrganization(ctx, "Test Org")
 	cat1, _ := fixtures.CreateCategory(ctx, org.ID, "Electronics", nil)
 	cat2, _ := fixtures.CreateCategory(ctx, org.ID, "Books", nil)
+	child, _ := fixtures.CreateCategory(ctx, org.ID, "Phones", &cat1.ID)
 
 	// Create assets in categories
 	fixtures.CreateAsset(ctx, org.ID, cat1.ID, "Phone 1")
 	fixtures.CreateAsset(ctx, org.ID, cat1.ID, "Phone 2")
 	fixtures.CreateAsset(ctx, org.ID, cat2.ID, "Book 1")
+	fixtures.CreateAsset(ctx, org.ID, child.ID, "Phone 3")
 
 	repo := NewCategoryRepository(testDB.Pool)
 	counts, err := repo.GetAssetCounts(ctx, org.ID)
@@ -447,10 +554,13 @@ func Test_CategoryRepository_GetAssetCounts(t *testing.T) {
 		t.Fatalf("failed to get asset counts: %v", err)
 	}
 
-	if counts[cat1.ID.String()] != 2 {
-		t.Errorf("expected 2 assets in cat1, got %d", counts[cat1.ID.String()])
+	if counts[cat1.ID.String()] != 3 {
+		t.Errorf("expected 3 assets in cat1 and descendants, got %d", counts[cat1.ID.String()])
 	}
 	if counts[cat2.ID.String()] != 1 {
 		t.Errorf("expected 1 asset in cat2, got %d", counts[cat2.ID.String()])
+	}
+	if counts[child.ID.String()] != 1 {
+		t.Errorf("expected 1 direct asset in child, got %d", counts[child.ID.String()])
 	}
 }

--- a/frontend/app/components/AssetCategoryField.vue
+++ b/frontend/app/components/AssetCategoryField.vue
@@ -1,0 +1,159 @@
+<script setup lang="ts">
+import type { Category } from '~/types/api'
+import { buildCategoryTreeRows } from '~/utils/categoryHierarchy'
+
+const props = defineProps<{
+  modelValue?: string
+  categories: Category[]
+  selectedCategory?: Category | null
+  loading?: boolean
+}>()
+
+const emit = defineEmits<{
+  'update:modelValue': [value: string | undefined]
+}>()
+
+const selection = computed({
+  get: () => props.modelValue,
+  set: value => emit('update:modelValue', value)
+})
+
+const rows = computed(() => buildCategoryTreeRows(props.categories))
+const options = computed(() => [
+  { label: 'No category', value: undefined, icon: 'i-lucide-inbox' },
+  ...rows.value.map(row => ({
+    label: [...row.ancestors, row.category].map(category => category.name).join(' / '),
+    value: row.category.id,
+    icon: row.category.icon || 'i-lucide-tag'
+  }))
+])
+
+const selectedRow = computed(() => rows.value.find(row => row.category.id === props.modelValue))
+const selectedFromList = computed(() => selectedRow.value?.category)
+const selectedPath = computed(() => selectedRow.value
+  ? selectedRow.value.ancestors.map(category => category.name).join(' / ')
+  : '')
+const directFieldCount = computed(() =>
+  props.selectedCategory?.attributes?.filter(attribute => !attribute.inherited).length || 0
+)
+const inheritedFieldCount = computed(() =>
+  props.selectedCategory?.attributes?.filter(attribute => attribute.inherited).length || 0
+)
+const availableFieldCount = computed(() => directFieldCount.value + inheritedFieldCount.value)
+</script>
+
+<template>
+  <div class="space-y-3">
+    <div class="flex flex-wrap items-end justify-between gap-2">
+      <div>
+        <label
+          for="asset-category"
+          class="block text-xs font-bold uppercase tracking-wider text-gray-500 dark:text-gray-400"
+        >
+          Category <span class="normal-case font-medium text-muted">(optional)</span>
+        </label>
+        <p class="mt-1 text-xs text-muted">
+          Choose the most specific category that fits this asset.
+        </p>
+      </div>
+      <NuxtLink
+        to="/categories"
+        class="text-xs font-bold text-attic-500 hover:text-attic-600 hover:underline"
+      >
+        Manage categories
+      </NuxtLink>
+    </div>
+
+    <USelectMenu
+      id="asset-category"
+      v-model="selection"
+      aria-label="Category"
+      :items="options"
+      value-key="value"
+      placeholder="Search or choose a category"
+      icon="i-lucide-tags"
+      size="lg"
+      class="w-full"
+    />
+
+    <div
+      v-if="selectedFromList"
+      class="flex items-start gap-3 rounded-xl border border-attic-200 bg-attic-50/60 p-3 dark:border-attic-800 dark:bg-attic-950/20"
+    >
+      <div class="flex size-9 shrink-0 items-center justify-center rounded-lg bg-white text-attic-500 shadow-sm dark:bg-mist-800">
+        <UIcon
+          :name="selectedFromList.icon || 'i-lucide-tag'"
+          class="size-4.5"
+        />
+      </div>
+      <div class="min-w-0 flex-1">
+        <p
+          v-if="selectedPath"
+          class="truncate text-[10px] font-extrabold uppercase tracking-[0.12em] text-attic-500"
+        >
+          {{ selectedPath }}
+        </p>
+        <p class="font-bold text-mist-950 dark:text-white">
+          {{ selectedFromList.name }}
+        </p>
+        <div class="mt-1 flex flex-wrap items-center gap-1.5 text-xs">
+          <span
+            v-if="loading"
+            class="inline-flex items-center gap-1.5 text-muted"
+          >
+            <UIcon
+              name="i-lucide-loader-2"
+              class="size-3 animate-spin"
+            />
+            Loading category fields…
+          </span>
+          <template v-else-if="availableFieldCount">
+            <span class="font-semibold text-mist-700 dark:text-mist-200">
+              {{ directFieldCount }} own
+            </span>
+            <template v-if="inheritedFieldCount">
+              <span class="text-muted">+</span>
+              <span class="font-semibold text-attic-600 dark:text-attic-300">
+                {{ inheritedFieldCount }} inherited
+              </span>
+            </template>
+            <span class="text-muted">·</span>
+            <a
+              href="#category-fields"
+              class="font-bold text-attic-600 hover:underline dark:text-attic-300"
+            >
+              {{ availableFieldCount }} {{ availableFieldCount === 1 ? 'field' : 'fields' }} to complete
+            </a>
+          </template>
+          <span
+            v-else
+            class="text-muted"
+          >
+            This category adds no extra fields.
+          </span>
+        </div>
+      </div>
+      <UIcon
+        name="i-lucide-check-circle-2"
+        class="mt-1 size-4 shrink-0 text-attic-500"
+      />
+    </div>
+
+    <p
+      v-else-if="!categories.length"
+      class="text-sm text-gray-400"
+    >
+      No categories available. You can keep this asset uncategorized or
+      <NuxtLink
+        to="/categories/new"
+        class="text-attic-500 hover:underline"
+      >create one</NuxtLink>.
+    </p>
+    <p
+      v-else
+      class="text-xs text-muted"
+    >
+      Without a category, this asset will not have category-specific fields.
+    </p>
+  </div>
+</template>

--- a/frontend/app/components/AssetCollectionsField.vue
+++ b/frontend/app/components/AssetCollectionsField.vue
@@ -7,14 +7,28 @@ const options = computed(() => data.value?.map(c => ({ label: c.name, value: c.i
 </script>
 
 <template>
-  <div class="space-y-2">
-    <label
-      for="asset-collections"
-      class="block text-sm font-semibold"
-    >Collections <span class="font-normal text-muted">(optional)</span></label>
-    <p class="text-xs text-muted">
-      Group this asset with others, such as PS5 games or furniture. Choose as many as you like.
-    </p>
+  <div class="space-y-3">
+    <div class="flex flex-wrap items-end justify-between gap-2">
+      <div>
+        <label
+          for="asset-collections"
+          class="block text-xs font-bold uppercase tracking-wider text-gray-500 dark:text-gray-400"
+        >
+          Collections <span class="normal-case font-medium text-muted">(optional)</span>
+        </label>
+        <p class="mt-1 text-xs text-muted">
+          Group this asset with others, such as PS5 games or furniture. Choose as many as you like.
+        </p>
+      </div>
+      <NuxtLink
+        to="/collections"
+        target="_blank"
+        rel="noopener noreferrer"
+        class="text-xs font-bold text-attic-500 hover:text-attic-600 hover:underline"
+      >
+        Manage collections
+      </NuxtLink>
+    </div>
     <div
       v-if="error"
       role="alert"
@@ -36,16 +50,13 @@ const options = computed(() => data.value?.map(c => ({ label: c.name, value: c.i
       :loading="status === 'pending'"
       :disabled="status === 'pending'"
       value-key="value"
-      placeholder="Choose collections"
+      placeholder="Search and choose a collection"
+      icon="i-lucide-library"
       aria-label="Collections"
       class="w-full"
+      size="lg"
     />
-    <div class="flex items-center justify-between gap-3 text-xs text-muted">
-      <NuxtLink
-        to="/collections"
-        target="_blank"
-        class="underline"
-      >Manage collections (opens in a new tab)</NuxtLink>
+    <div class="flex items-center justify-end gap-3 text-xs text-muted">
       <UButton
         v-if="model.length"
         color="neutral"

--- a/frontend/app/pages/assets/[id]/edit.vue
+++ b/frontend/app/pages/assets/[id]/edit.vue
@@ -25,6 +25,7 @@ function revealInvalidSection(event: Event) {
 }
 
 const loading = ref(false)
+const categoryLoading = ref(false)
 const selectedCategory = ref<Category | null>(null)
 const form = reactive({
   collection_ids: [] as string[],
@@ -44,7 +45,7 @@ const form = reactive({
 // Initialize form when asset loads
 watch(
   asset,
-  async (newAsset) => {
+  (newAsset) => {
     if (newAsset) {
       form.name = newAsset.name
       form.description = newAsset.description || ''
@@ -71,34 +72,25 @@ watch(
       purchaseOpen.value = Boolean(
         form.purchase_at || form.purchase_price != null || form.purchase_note.trim()
       )
-
-      // Load category with attributes
-      if (newAsset.category_id) {
-        try {
-          selectedCategory.value = await apiFetch<Category>(
-            `/api/categories/${newAsset.category_id}`
-          )
-        } catch {
-          selectedCategory.value = null
-        }
-      }
     }
   },
   { immediate: true }
 )
 
 // Fetch category with attributes when category changes
+let categoryRequestId = 0
 watch(
   () => form.category_id,
-  async (categoryId, oldCategoryId) => {
-    // Skip if this is the initial load (handled by asset watch)
-    if (!oldCategoryId) return
-
+  async (categoryId) => {
+    const requestId = ++categoryRequestId
     if (categoryId) {
+      categoryLoading.value = true
       try {
-        selectedCategory.value = await apiFetch<Category>(
-          `/api/categories/${categoryId}`
+        const category = await apiFetch<Category>(
+          `/api/categories/${categoryId}?inherited=true`
         )
+        if (requestId !== categoryRequestId) return
+        selectedCategory.value = category
         // Initialize attribute values for new category
         const newAttributes: Record<string, string | number | boolean> = {}
         selectedCategory.value?.attributes?.forEach((ca) => {
@@ -111,13 +103,17 @@ watch(
         })
         form.attributes = newAttributes
       } catch {
-        selectedCategory.value = null
+        if (requestId === categoryRequestId) selectedCategory.value = null
+      } finally {
+        if (requestId === categoryRequestId) categoryLoading.value = false
       }
     } else {
+      categoryLoading.value = false
       selectedCategory.value = null
       form.attributes = {}
     }
-  }
+  },
+  { immediate: true }
 )
 
 function getDefaultValue(dataType: string): string | number | boolean {
@@ -416,69 +412,12 @@ async function submitForm() {
               </div>
             </div>
 
-            <!-- Category Grid -->
-            <div class="space-y-3">
-              <label class="block text-xs font-bold text-gray-500 dark:text-gray-400 uppercase tracking-wider">
-                Category <span class="normal-case font-medium text-muted">(optional)</span>
-              </label>
-              <div class="flex flex-wrap gap-2">
-                <label class="group relative min-w-36 cursor-pointer">
-                  <input
-                    v-model="form.category_id"
-                    type="radio"
-                    name="category"
-                    :value="undefined"
-                    class="peer sr-only"
-                  >
-                  <div class="flex h-11 items-center gap-2 rounded-xl border border-mist-200 bg-mist-50/50 px-3 pr-8 transition-all hover:border-attic-300 hover:bg-attic-50/50 peer-focus-visible:outline-2 peer-focus-visible:outline-offset-2 peer-focus-visible:outline-attic-500 peer-checked:border-attic-500 peer-checked:bg-attic-50 peer-checked:ring-2 peer-checked:ring-attic-500/10 dark:border-mist-700 dark:bg-mist-800 dark:peer-checked:bg-attic-500/10">
-                    <UIcon
-                      name="i-lucide-inbox"
-                      class="size-4 shrink-0 text-muted transition-colors group-hover:text-attic-500"
-                    />
-                    <span class="truncate text-xs font-bold text-mist-600 dark:text-mist-300">No category</span>
-                  </div>
-                  <UIcon
-                    name="i-lucide-check-circle"
-                    class="absolute right-2.5 top-3 size-4 text-attic-500 opacity-0 transition-opacity peer-checked:opacity-100"
-                  />
-                </label>
-                <label
-                  v-for="cat in categories"
-                  :key="cat.id"
-                  class="group relative min-w-36 cursor-pointer"
-                >
-                  <input
-                    v-model="form.category_id"
-                    type="radio"
-                    name="category"
-                    :value="cat.id"
-                    class="peer sr-only"
-                  >
-                  <div class="flex h-11 items-center gap-2 rounded-xl border border-mist-200 bg-mist-50/50 px-3 pr-8 transition-all hover:border-attic-300 hover:bg-attic-50/50 peer-checked:border-attic-500 peer-checked:bg-attic-50 peer-checked:ring-2 peer-checked:ring-attic-500/10 dark:border-mist-700 dark:bg-mist-800 dark:peer-checked:bg-attic-500/10">
-                    <UIcon
-                      name="i-lucide-folder"
-                      class="size-4 shrink-0 text-muted transition-colors group-hover:text-attic-500"
-                    />
-                    <span class="truncate text-xs font-bold text-mist-600 dark:text-mist-300">{{ cat.name }}</span>
-                  </div>
-                  <div class="absolute right-2.5 top-3 text-attic-500 opacity-0 transition-opacity peer-checked:opacity-100">
-                    <UIcon
-                      name="i-lucide-check-circle"
-                      class="w-4 h-4"
-                    />
-                  </div>
-                </label>
-              </div>
-              <p
-                v-if="!categories?.length"
-                class="text-sm text-gray-400"
-              >
-                No categories available. You can keep this asset uncategorized or <NuxtLink
-                  to="/categories"
-                  class="text-attic-500 hover:underline"
-                >create one</NuxtLink>.
-              </p>
-            </div>
+            <AssetCategoryField
+              v-model="form.category_id"
+              :categories="categories || []"
+              :selected-category="selectedCategory"
+              :loading="categoryLoading"
+            />
             <AssetCollectionsField v-model="form.collection_ids" />
           </section>
 
@@ -572,7 +511,10 @@ async function submitForm() {
           <template v-if="selectedCategory?.attributes?.length">
             <hr class="hidden">
 
-            <section class="attic-panel space-y-5 rounded-[20px] p-5 sm:p-6">
+            <section
+              id="category-fields"
+              class="attic-panel scroll-mt-6 space-y-5 rounded-[20px] p-5 sm:p-6"
+            >
               <div class="flex items-start gap-3">
                 <div class="flex size-9 shrink-0 items-center justify-center rounded-xl bg-terracotta-50 text-terracotta-500 dark:bg-terracotta-500/10 dark:text-terracotta-300">
                   <UIcon
@@ -582,10 +524,10 @@ async function submitForm() {
                 </div>
                 <div>
                   <h2 class="font-extrabold text-mist-950 dark:text-white">
-                    {{ selectedCategory.name }} attributes
+                    {{ selectedCategory.name }} fields
                   </h2>
                   <p class="text-xs text-muted">
-                    Category-specific information for this asset.
+                    Includes fields inherited through the category hierarchy.
                   </p>
                 </div>
               </div>
@@ -599,6 +541,10 @@ async function submitForm() {
                   <template v-if="ca.attribute">
                     <label class="block text-xs font-bold text-gray-500 dark:text-gray-400 uppercase tracking-wider">
                       {{ ca.attribute.name }}
+                      <span
+                        v-if="ca.inherited"
+                        class="ml-1 normal-case font-semibold text-attic-500"
+                      >(inherited)</span>
                       <span
                         v-if="ca.required"
                         class="text-amber-500"

--- a/frontend/app/pages/assets/[id]/index.vue
+++ b/frontend/app/pages/assets/[id]/index.vue
@@ -22,7 +22,7 @@ const categoryWithAttrs = ref<Category | null>(null)
 watch(() => asset.value?.category_id, async (categoryId) => {
   if (categoryId) {
     try {
-      categoryWithAttrs.value = await apiFetch<Category>(`/api/categories/${categoryId}`)
+      categoryWithAttrs.value = await apiFetch<Category>(`/api/categories/${categoryId}?inherited=true`)
     } catch {
       categoryWithAttrs.value = null
     }

--- a/frontend/app/pages/assets/index.vue
+++ b/frontend/app/pages/assets/index.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import type { Collection, Category, Location, Condition, AssetsResponse, AssetFilters, Asset } from '~/types/api'
+import { buildCategoryOptions } from '~/utils/categoryHierarchy'
 
 const uncategorizedCategoryFilter = 'uncategorized'
 
@@ -78,7 +79,7 @@ const { data: conditions } = useApi<Condition[]>('/api/conditions')
 const categoryOptions = computed(() =>
   [
     { label: 'Uncategorized', value: uncategorizedCategoryFilter },
-    ...(categories.value?.map(c => ({ label: c.name, value: c.id })) || [])
+    ...buildCategoryOptions(categories.value || [])
   ]
 )
 

--- a/frontend/app/pages/assets/new.vue
+++ b/frontend/app/pages/assets/new.vue
@@ -16,6 +16,7 @@ const { data: locations } = useApi<Location[]>('/api/locations')
 const { data: conditions } = useApi<Condition[]>('/api/conditions')
 
 const loading = ref(false)
+const categoryLoading = ref(false)
 const selectedCategory = ref<Category | null>(null)
 const form = reactive({
   collection_ids: [] as string[],
@@ -37,10 +38,6 @@ watch(() => route.query.location_id, (locationId) => {
     form.location_id = locationId
   }
 }, { immediate: true })
-
-const _categoryOptions = computed(() =>
-  categories.value?.map(c => ({ label: c.name, value: c.id, icon: c.icon })) || []
-)
 
 interface LocationOption {
   label: string
@@ -96,10 +93,15 @@ const conditionOptions = computed(() => [
 ])
 
 // Fetch category with attributes when category changes
+let categoryRequestId = 0
 watch(() => form.category_id, async (categoryId) => {
+  const requestId = ++categoryRequestId
   if (categoryId) {
+    categoryLoading.value = true
     try {
-      selectedCategory.value = await apiFetch<Category>(`/api/categories/${categoryId}`)
+      const category = await apiFetch<Category>(`/api/categories/${categoryId}?inherited=true`)
+      if (requestId !== categoryRequestId) return
+      selectedCategory.value = category
       // Initialize attribute values
       form.attributes = {}
       selectedCategory.value?.attributes?.forEach((ca) => {
@@ -108,9 +110,12 @@ watch(() => form.category_id, async (categoryId) => {
         }
       })
     } catch {
-      selectedCategory.value = null
+      if (requestId === categoryRequestId) selectedCategory.value = null
+    } finally {
+      if (requestId === categoryRequestId) categoryLoading.value = false
     }
   } else {
+    categoryLoading.value = false
     selectedCategory.value = null
     form.attributes = {}
   }
@@ -325,69 +330,12 @@ async function submitForm() {
             </div>
           </div>
 
-          <!-- Category Grid -->
-          <div class="space-y-3">
-            <label class="block text-xs font-bold text-gray-500 dark:text-gray-400 uppercase tracking-wider">
-              Category <span class="normal-case font-medium text-muted">(optional)</span>
-            </label>
-            <div class="flex flex-wrap gap-2">
-              <label class="group relative min-w-36 cursor-pointer">
-                <input
-                  v-model="form.category_id"
-                  type="radio"
-                  name="category"
-                  :value="undefined"
-                  class="peer sr-only"
-                >
-                <div class="flex h-11 items-center gap-2 rounded-xl border border-mist-200 bg-mist-50/50 px-3 pr-8 transition-all hover:border-attic-300 hover:bg-attic-50/50 peer-focus-visible:outline-2 peer-focus-visible:outline-offset-2 peer-focus-visible:outline-attic-500 peer-checked:border-attic-500 peer-checked:bg-attic-50 peer-checked:ring-2 peer-checked:ring-attic-500/10 dark:border-mist-700 dark:bg-mist-800 dark:peer-checked:bg-attic-500/10">
-                  <UIcon
-                    name="i-lucide-inbox"
-                    class="size-4 shrink-0 text-muted transition-colors group-hover:text-attic-500"
-                  />
-                  <span class="truncate text-xs font-bold text-mist-600 dark:text-mist-300">No category</span>
-                </div>
-                <UIcon
-                  name="i-lucide-check-circle"
-                  class="absolute right-2.5 top-3 size-4 text-attic-500 opacity-0 transition-opacity peer-checked:opacity-100"
-                />
-              </label>
-              <label
-                v-for="cat in categories"
-                :key="cat.id"
-                class="group relative min-w-36 cursor-pointer"
-              >
-                <input
-                  v-model="form.category_id"
-                  type="radio"
-                  name="category"
-                  :value="cat.id"
-                  class="peer sr-only"
-                >
-                <div class="flex h-11 items-center gap-2 rounded-xl border border-mist-200 bg-mist-50/50 px-3 pr-8 transition-all hover:border-attic-300 hover:bg-attic-50/50 peer-focus-visible:outline-2 peer-focus-visible:outline-offset-2 peer-focus-visible:outline-attic-500 peer-checked:border-attic-500 peer-checked:bg-attic-50 peer-checked:ring-2 peer-checked:ring-attic-500/10 dark:border-mist-700 dark:bg-mist-800 dark:peer-checked:bg-attic-500/10">
-                  <UIcon
-                    name="i-lucide-folder"
-                    class="size-4 shrink-0 text-muted transition-colors group-hover:text-attic-500"
-                  />
-                  <span class="truncate text-xs font-bold text-mist-600 dark:text-mist-300">{{ cat.name }}</span>
-                </div>
-                <div class="absolute right-2.5 top-3 text-attic-500 opacity-0 transition-opacity peer-checked:opacity-100">
-                  <UIcon
-                    name="i-lucide-check-circle"
-                    class="w-4 h-4"
-                  />
-                </div>
-              </label>
-            </div>
-            <p
-              v-if="!categories?.length"
-              class="text-sm text-gray-400"
-            >
-              No categories available. You can save this asset now or <NuxtLink
-                to="/categories"
-                class="text-attic-500 hover:underline"
-              >create one</NuxtLink>.
-            </p>
-          </div>
+          <AssetCategoryField
+            v-model="form.category_id"
+            :categories="categories || []"
+            :selected-category="selectedCategory"
+            :loading="categoryLoading"
+          />
           <AssetCollectionsField v-model="form.collection_ids" />
         </section>
 
@@ -492,7 +440,10 @@ async function submitForm() {
         <template v-if="selectedCategory?.attributes?.length">
           <hr class="hidden">
 
-          <section class="attic-panel space-y-5 rounded-[20px] p-5 sm:p-6">
+          <section
+            id="category-fields"
+            class="attic-panel scroll-mt-6 space-y-5 rounded-[20px] p-5 sm:p-6"
+          >
             <div class="flex items-start gap-3">
               <div class="flex size-9 shrink-0 items-center justify-center rounded-xl bg-terracotta-50 text-terracotta-500 dark:bg-terracotta-500/10 dark:text-terracotta-300">
                 <UIcon
@@ -502,10 +453,10 @@ async function submitForm() {
               </div>
               <div>
                 <h2 class="font-extrabold text-mist-950 dark:text-white">
-                  {{ selectedCategory.name }} attributes
+                  {{ selectedCategory.name }} fields
                 </h2>
                 <p class="text-xs text-muted">
-                  Category-specific information for this asset.
+                  Includes fields inherited through the category hierarchy.
                 </p>
               </div>
             </div>
@@ -519,6 +470,10 @@ async function submitForm() {
                 <template v-if="ca.attribute">
                   <label class="block text-xs font-bold text-gray-500 dark:text-gray-400 uppercase tracking-wider">
                     {{ ca.attribute.name }}
+                    <span
+                      v-if="ca.inherited"
+                      class="ml-1 normal-case font-semibold text-attic-500"
+                    >(inherited)</span>
                     <span
                       v-if="ca.required"
                       class="text-amber-500"

--- a/frontend/app/pages/categories/[id]/edit.vue
+++ b/frontend/app/pages/categories/[id]/edit.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { getIconLabel } from '~/utils/iconLabel'
+import { buildCategoryOptions, getCategoryDescendantIds, getInheritedCategoryAttributes } from '~/utils/categoryHierarchy'
 import type { Category, Attribute } from '~/types/api'
 
 definePageMeta({
@@ -18,6 +19,7 @@ const { data: category, status: categoryStatus } = useApi<Category>(
   () => `/api/categories/${categoryId.value}`
 )
 const { data: attributes } = useApi<Attribute[]>('/api/attributes')
+const { data: categories } = useApi<Category[]>('/api/categories')
 
 // Form state
 const form = reactive({
@@ -36,6 +38,16 @@ interface AttributeSelection {
 
 const selectedAttributes = ref<AttributeSelection[]>([])
 const draggedAttributeId = ref<string | null>(null)
+const excludedParentIds = computed(() =>
+  getCategoryDescendantIds(categories.value || [], categoryId.value)
+)
+const parentOptions = computed(() => [
+  { label: 'None (Top Level)', value: undefined },
+  ...buildCategoryOptions(categories.value || [], excludedParentIds.value)
+])
+const inheritedAttributes = computed(() =>
+  getInheritedCategoryAttributes(categories.value || [], form.parent_id)
+)
 
 // Initialize form when category loads
 watch(category, (cat) => {
@@ -126,6 +138,7 @@ const availableAttributes = computed(() => {
   if (!attributes.value) return []
   return attributes.value.filter(
     a => !selectedAttributes.value.some(sa => sa.attribute_id === a.id)
+      && !inheritedAttributes.value.some(ia => ia.attribute_id === a.id)
   )
 })
 
@@ -367,6 +380,27 @@ function cancel() {
                   <span class="text-xs text-muted">{{ descriptionCount }}/140</span>
                 </div>
               </div>
+              <div>
+                <label class="mb-2 block text-xs font-bold uppercase tracking-wider text-muted">
+                  Parent Category
+                </label>
+                <select
+                  :value="form.parent_id ?? ''"
+                  class="w-full rounded-xl border border-mist-200 bg-white px-4 py-3 text-sm font-medium text-mist-950 shadow-sm outline-none transition-all focus:border-attic-500 focus:ring-1 focus:ring-attic-500 dark:border-mist-600 dark:bg-mist-800 dark:text-white"
+                  @change="form.parent_id = ($event.target as HTMLSelectElement).value || undefined"
+                >
+                  <option
+                    v-for="option in parentOptions"
+                    :key="option.value ?? 'none'"
+                    :value="option.value ?? ''"
+                  >
+                    {{ option.label }}
+                  </option>
+                </select>
+                <p class="mt-1 text-xs text-muted">
+                  Inherited fields are available to every asset in this category.
+                </p>
+              </div>
             </div>
           </section>
 
@@ -460,6 +494,23 @@ function cancel() {
                     >
                       {{ selectedAttributes.length }} selected
                     </span>
+                  </div>
+
+                  <div
+                    v-if="inheritedAttributes.length"
+                    class="mb-5 space-y-2 rounded-xl border border-attic-200 bg-attic-50/60 p-4 dark:border-attic-800 dark:bg-attic-950/20"
+                  >
+                    <p class="text-xs font-bold uppercase tracking-wider text-attic-600 dark:text-attic-300">
+                      Inherited fields
+                    </p>
+                    <div
+                      v-for="assignment in inheritedAttributes"
+                      :key="assignment.attribute_id"
+                      class="flex items-center justify-between text-sm"
+                    >
+                      <span class="font-semibold text-mist-800 dark:text-mist-100">{{ assignment.attribute?.name || getAttribute(assignment.attribute_id)?.name }}</span>
+                      <span class="text-xs text-muted">{{ assignment.required ? 'Required' : 'Optional' }}</span>
+                    </div>
                   </div>
 
                   <!-- Selected Attributes -->

--- a/frontend/app/pages/categories/index.vue
+++ b/frontend/app/pages/categories/index.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import type { Category } from '~/types/api'
+import { buildCategoryTreeRows, getInheritedCategoryAttributes } from '~/utils/categoryHierarchy'
 
 definePageMeta({
   middleware: 'auth'
@@ -24,7 +25,7 @@ const search = ref('')
 
 async function viewAttributes(category: Category) {
   try {
-    const fullCategory = await apiFetch<Category>(`/api/categories/${category.id}`)
+    const fullCategory = await apiFetch<Category>(`/api/categories/${category.id}?inherited=true`)
     viewingCategory.value = fullCategory
     attributesModalOpen.value = true
   } catch {
@@ -56,8 +57,11 @@ async function deleteCategory() {
 // Stats
 const totalCategories = computed(() => categories.value?.length || 0)
 const totalItems = computed(() => {
-  if (!categoryAssetCounts.value) return 0
-  return Object.values(categoryAssetCounts.value).reduce((sum, count) => sum + count, 0)
+  if (!categoryAssetCounts.value || !categories.value) return 0
+  const activeIds = new Set(categories.value.map(category => category.id))
+  return categories.value
+    .filter(category => !category.parent_id || !activeIds.has(category.parent_id))
+    .reduce((sum, category) => sum + (categoryAssetCounts.value?.[category.id] || 0), 0)
 })
 const uniqueFields = computed(() => {
   const fieldIds = new Set(
@@ -68,15 +72,49 @@ const uniqueFields = computed(() => {
   return fieldIds.size
 })
 
-const filteredCategories = computed(() => {
-  const query = search.value.trim().toLowerCase()
-  if (!query) return categories.value || []
+const categoryRows = computed(() => buildCategoryTreeRows(categories.value || []).map((row) => {
+  const directAttributeIds = new Set((row.category.attributes || []).map(attribute => attribute.attribute_id))
+  const inheritedAttributes = getInheritedCategoryAttributes(categories.value || [], row.category.parent_id)
+    .filter(attribute => !directAttributeIds.has(attribute.attribute_id))
+  return {
+    ...row,
+    directFieldCount: directAttributeIds.size,
+    inheritedFieldCount: inheritedAttributes.length,
+    availableFieldCount: directAttributeIds.size + inheritedAttributes.length
+  }
+}))
 
-  return (categories.value || []).filter(category =>
-    category.name.toLowerCase().includes(query)
-    || category.description?.toLowerCase().includes(query)
-  )
+const filteredCategoryRows = computed(() => {
+  const query = search.value.trim().toLowerCase()
+  if (!query) return categoryRows.value
+
+  const matches = new Set(categoryRows.value.filter(row =>
+    row.category.name.toLowerCase().includes(query)
+    || row.category.description?.toLowerCase().includes(query)
+    || [...row.ancestors, row.category].some(category => category.name.toLowerCase().includes(query))
+  ).map(row => row.category.id))
+  const visible = new Set(matches)
+  for (const row of categoryRows.value) {
+    if (matches.has(row.category.id)) {
+      row.ancestors.forEach(ancestor => visible.add(ancestor.id))
+    }
+  }
+  return categoryRows.value.filter(row => visible.has(row.category.id))
 })
+
+const categoryGroups = computed(() => {
+  const groups = new Map<string, typeof filteredCategoryRows.value>()
+  for (const row of filteredCategoryRows.value) {
+    const group = groups.get(row.rootId) || []
+    group.push(row)
+    groups.set(row.rootId, group)
+  }
+  return [...groups.values()]
+})
+
+function getCategoryName(categoryId: string): string {
+  return categories.value?.find(category => category.id === categoryId)?.name || 'ancestor category'
+}
 
 // Get asset count for a category
 function getAssetCount(categoryId: string): number {
@@ -176,9 +214,23 @@ function getAttributeStyle(dataType: string): { icon: string, bgColor: string, t
         v-model="search"
         title="Category library"
         placeholder="Search categories"
-        :count="filteredCategories.length"
+        :count="filteredCategoryRows.length"
         :total="totalCategories"
       />
+      <div class="flex gap-3 rounded-2xl border border-attic-200 bg-attic-50/70 px-4 py-3 dark:border-attic-800 dark:bg-attic-950/20">
+        <UIcon
+          name="i-lucide-git-branch"
+          class="mt-0.5 size-5 shrink-0 text-attic-500"
+        />
+        <div>
+          <p class="text-sm font-bold text-mist-900 dark:text-white">
+            Fields flow down the category tree
+          </p>
+          <p class="mt-0.5 text-xs leading-5 text-muted">
+            A child receives the fields of every category above it. Fields added directly to the child can refine that inherited setup.
+          </p>
+        </div>
+      </div>
       <!-- Loading State -->
       <div
         v-if="status === 'pending'"
@@ -213,7 +265,7 @@ function getAttributeStyle(dataType: string): { icon: string, bgColor: string, t
       </div>
 
       <div
-        v-else-if="!filteredCategories.length"
+        v-else-if="!filteredCategoryRows.length"
         class="px-4 py-14 text-center"
       >
         <UIcon
@@ -234,42 +286,133 @@ function getAttributeStyle(dataType: string): { icon: string, bgColor: string, t
 
       <div
         v-else
-        class="attic-panel overflow-hidden rounded-[20px]"
+        role="tree"
+        aria-label="Category inheritance tree"
+        class="space-y-4"
       >
-        <div class="hidden grid-cols-[minmax(0,1.05fr)_minmax(0,1.35fr)_auto] gap-4 border-b border-mist-100 bg-mist-50/70 px-5 py-2.5 text-[10px] font-extrabold uppercase tracking-[0.14em] text-muted dark:border-mist-700 dark:bg-mist-800/70 sm:grid">
-          <span>Category</span>
-          <span>Details</span>
-          <span class="pr-2 text-right">Actions</span>
-        </div>
-        <div
-          role="list"
-          class="divide-y divide-mist-100 dark:divide-mist-700"
+        <section
+          v-for="group in categoryGroups"
+          :key="group[0]?.rootId"
+          class="attic-panel overflow-hidden rounded-[20px]"
         >
-          <LibraryCard
-            v-for="category in filteredCategories"
-            :key="category.id"
-            :name="category.name"
-            :description="category.description"
-            :icon="getCategoryStyle(category).icon"
-            :icon-class="getCategoryStyle(category).bgColor + ' ' + getCategoryStyle(category).textColor"
-            :asset-count="getAssetCount(category.id)"
-            :assets-to="'/assets?category_id=' + encodeURIComponent(category.id)"
-            :edit-to="'/categories/' + category.id + '/edit'"
-            @delete="confirmDelete(category)"
+          <article
+            v-for="row in group"
+            :key="row.category.id"
+            role="treeitem"
+            :aria-level="row.depth + 1"
+            class="relative border-b border-mist-100 px-4 py-4 last:border-b-0 dark:border-mist-700 sm:px-5"
+            :class="row.depth === 0 ? 'bg-mist-50/60 dark:bg-mist-800/50' : 'bg-white dark:bg-mist-800'"
           >
-            <template #metadata>
-              <UButton
-                icon="i-lucide-list-checks"
-                variant="soft"
-                size="xs"
-                :aria-label="'View fields for ' + category.name"
-                @click="viewAttributes(category)"
-              >
-                {{ category.attributes?.length || 0 }} {{ category.attributes?.length === 1 ? 'field' : 'fields' }}
-              </UButton>
-            </template>
-          </LibraryCard>
-        </div>
+            <div
+              class="grid gap-4 sm:grid-cols-[minmax(0,1.1fr)_minmax(0,1fr)_auto] sm:items-center"
+              :style="{ marginLeft: `min(${Math.min(row.depth, 6) * 4}vw, ${Math.min(row.depth, 6) * 28}px)` }"
+            >
+              <div class="relative flex min-w-0 items-start gap-3">
+                <span
+                  v-if="row.depth > 0"
+                  aria-hidden="true"
+                  class="absolute right-full top-0 mr-2 h-6 w-5 rounded-bl-xl border-b-2 border-l-2 border-attic-200 dark:border-attic-700"
+                />
+                <div
+                  class="flex size-10 shrink-0 items-center justify-center rounded-xl"
+                  :class="[getCategoryStyle(row.category).bgColor, getCategoryStyle(row.category).textColor]"
+                >
+                  <UIcon
+                    :name="getCategoryStyle(row.category).icon"
+                    class="size-5"
+                  />
+                </div>
+                <div class="min-w-0">
+                  <p
+                    v-if="row.ancestors.length"
+                    class="truncate text-[10px] font-extrabold uppercase tracking-[0.12em] text-attic-500"
+                  >
+                    {{ row.ancestors.map(ancestor => ancestor.name).join(' / ') }}
+                  </p>
+                  <h2 class="truncate font-extrabold text-mist-950 dark:text-white">
+                    {{ row.category.name }}
+                  </h2>
+                  <p
+                    v-if="row.category.description"
+                    class="mt-0.5 line-clamp-2 text-xs text-muted"
+                  >
+                    {{ row.category.description }}
+                  </p>
+                  <p
+                    v-if="row.childCount"
+                    class="mt-1 text-[11px] font-semibold text-muted"
+                  >
+                    {{ row.childCount }} direct {{ row.childCount === 1 ? 'child' : 'children' }}
+                  </p>
+                </div>
+              </div>
+
+              <div class="flex flex-wrap items-center gap-2">
+                <button
+                  type="button"
+                  class="rounded-full bg-mist-100 px-2.5 py-1 text-xs font-bold text-mist-700 transition hover:bg-mist-200 dark:bg-mist-700 dark:text-mist-100 dark:hover:bg-mist-600"
+                  :aria-label="'View available fields for ' + row.category.name"
+                  @click="viewAttributes(row.category)"
+                >
+                  {{ row.directFieldCount }} own
+                </button>
+                <template v-if="row.inheritedFieldCount">
+                  <UIcon
+                    name="i-lucide-plus"
+                    class="size-3 text-muted"
+                  />
+                  <button
+                    type="button"
+                    class="rounded-full bg-attic-100 px-2.5 py-1 text-xs font-bold text-attic-700 transition hover:bg-attic-200 dark:bg-attic-900/40 dark:text-attic-300"
+                    :aria-label="'View inherited fields for ' + row.category.name"
+                    @click="viewAttributes(row.category)"
+                  >
+                    {{ row.inheritedFieldCount }} inherited
+                  </button>
+                  <span class="text-xs font-bold text-mist-700 dark:text-mist-200">
+                    = {{ row.availableFieldCount }} available
+                  </span>
+                </template>
+              </div>
+
+              <div class="flex flex-wrap items-center gap-1 sm:justify-end">
+                <UButton
+                  :to="'/assets?category_id=' + encodeURIComponent(row.category.id)"
+                  icon="i-lucide-box"
+                  variant="ghost"
+                  color="neutral"
+                  size="xs"
+                >
+                  {{ getAssetCount(row.category.id) }}
+                </UButton>
+                <UButton
+                  :to="{ path: '/categories/new', query: { parent_id: row.category.id } }"
+                  icon="i-lucide-git-branch-plus"
+                  variant="ghost"
+                  color="neutral"
+                  size="xs"
+                  :aria-label="'Add child category under ' + row.category.name"
+                />
+                <UButton
+                  :to="'/categories/' + row.category.id + '/edit'"
+                  icon="i-lucide-pencil"
+                  variant="ghost"
+                  color="neutral"
+                  size="xs"
+                  :aria-label="'Edit ' + row.category.name"
+                />
+                <UButton
+                  icon="i-lucide-trash-2"
+                  variant="ghost"
+                  color="error"
+                  size="xs"
+                  :aria-label="'Delete ' + row.category.name"
+                  @click="confirmDelete(row.category)"
+                />
+              </div>
+            </div>
+          </article>
+        </section>
       </div>
     </section>
 
@@ -319,8 +462,8 @@ function getAttributeStyle(dataType: string): { icon: string, bgColor: string, t
     <!-- Attributes View Modal -->
     <UModal
       v-model:open="attributesModalOpen"
-      :title="`${viewingCategory?.name || 'Category'} Attributes`"
-      :description="`${viewingCategory?.attributes?.length || 0} attributes defined`"
+      :title="`${viewingCategory?.name || 'Category'} fields`"
+      :description="`${viewingCategory?.attributes?.length || 0} fields available, including inherited fields`"
     >
       <template #content>
         <div class="bg-white dark:bg-mist-800 rounded-xl shadow-xl max-w-md w-full">
@@ -338,10 +481,10 @@ function getAttributeStyle(dataType: string): { icon: string, bgColor: string, t
               </div>
               <div>
                 <h3 class="text-lg font-bold text-mist-950 dark:text-white">
-                  {{ viewingCategory?.name }} Attributes
+                  {{ viewingCategory?.name }} fields
                 </h3>
                 <p class="text-sm text-muted">
-                  {{ viewingCategory?.attributes?.length || 0 }} attributes defined
+                  {{ viewingCategory?.attributes?.length || 0 }} available on assets in this category
                 </p>
               </div>
             </div>
@@ -357,7 +500,7 @@ function getAttributeStyle(dataType: string): { icon: string, bgColor: string, t
                 class="w-10 h-10 text-mist-300 mx-auto mb-3"
               />
               <p class="text-sm text-muted">
-                No attributes defined for this category.
+                No fields are available for this category.
               </p>
             </div>
 
@@ -370,7 +513,7 @@ function getAttributeStyle(dataType: string): { icon: string, bgColor: string, t
                 :key="attr.id"
                 class="flex items-center justify-between p-3 bg-mist-50 dark:bg-mist-700/50 rounded-lg"
               >
-                <div class="flex items-center gap-3">
+                <div class="flex min-w-0 items-center gap-3">
                   <div
                     class="size-8 rounded flex items-center justify-center"
                     :class="[getAttributeStyle(attr.attribute?.data_type || 'string').bgColor, getAttributeStyle(attr.attribute?.data_type || 'string').textColor]"
@@ -380,9 +523,23 @@ function getAttributeStyle(dataType: string): { icon: string, bgColor: string, t
                       class="w-4 h-4"
                     />
                   </div>
-                  <span class="font-medium text-mist-950 dark:text-white">
-                    {{ attr.attribute?.name || 'Unknown' }}
-                  </span>
+                  <div class="min-w-0">
+                    <p class="truncate font-medium text-mist-950 dark:text-white">
+                      {{ attr.attribute?.name || 'Unknown' }}
+                    </p>
+                    <p
+                      v-if="attr.inherited"
+                      class="truncate text-[11px] font-semibold text-attic-500"
+                    >
+                      Inherited from {{ getCategoryName(attr.category_id) }}
+                    </p>
+                    <p
+                      v-else
+                      class="text-[11px] text-muted"
+                    >
+                      Defined here
+                    </p>
+                  </div>
                 </div>
                 <div class="flex items-center gap-2">
                   <span class="text-xs text-muted bg-mist-200 dark:bg-mist-600 px-2 py-0.5 rounded">

--- a/frontend/app/pages/categories/new.vue
+++ b/frontend/app/pages/categories/new.vue
@@ -1,23 +1,26 @@
 <script setup lang="ts">
 import { getIconLabel } from '~/utils/iconLabel'
-import type { Attribute } from '~/types/api'
+import { buildCategoryOptions, getInheritedCategoryAttributes } from '~/utils/categoryHierarchy'
+import type { Category, Attribute } from '~/types/api'
 
 definePageMeta({
   middleware: 'auth'
 })
 
 const router = useRouter()
+const route = useRoute()
 const toast = useToast()
 const apiFetch = useApiFetch()
 
 const { data: attributes } = useApi<Attribute[]>('/api/attributes')
+const { data: categories } = useApi<Category[]>('/api/categories')
 
 // Form state
 const form = reactive({
   name: '',
   description: '',
   icon: 'i-lucide-tag',
-  parent_id: undefined as string | undefined
+  parent_id: typeof route.query.parent_id === 'string' ? route.query.parent_id : undefined
 })
 
 // Attribute selection
@@ -28,6 +31,13 @@ interface AttributeSelection {
 }
 
 const selectedAttributes = ref<AttributeSelection[]>([])
+const parentOptions = computed(() => [
+  { label: 'None (Top Level)', value: undefined },
+  ...buildCategoryOptions(categories.value || [])
+])
+const inheritedAttributes = computed(() =>
+  getInheritedCategoryAttributes(categories.value || [], form.parent_id)
+)
 
 // Search query for attribute library
 const attributeSearch = ref('')
@@ -103,6 +113,7 @@ const availableAttributes = computed(() => {
   if (!attributes.value) return []
   return attributes.value.filter(
     a => !selectedAttributes.value.some(sa => sa.attribute_id === a.id)
+      && !inheritedAttributes.value.some(ia => ia.attribute_id === a.id)
   )
 })
 
@@ -283,6 +294,27 @@ function cancel() {
                 <span class="text-xs text-muted">{{ descriptionCount }}/140</span>
               </div>
             </div>
+            <div>
+              <label class="block text-sm font-semibold text-mist-700 dark:text-mist-300 mb-2">
+                Parent Category
+              </label>
+              <select
+                :value="form.parent_id ?? ''"
+                class="w-full rounded-lg border border-mist-200 bg-mist-50 px-4 py-3 text-sm font-medium text-mist-950 outline-none focus:border-attic-500 focus:ring-1 focus:ring-attic-500 dark:border-mist-600 dark:bg-mist-900 dark:text-white"
+                @change="form.parent_id = ($event.target as HTMLSelectElement).value || undefined"
+              >
+                <option
+                  v-for="option in parentOptions"
+                  :key="option.value ?? 'none'"
+                  :value="option.value ?? ''"
+                >
+                  {{ option.label }}
+                </option>
+              </select>
+              <p class="mt-1 text-xs text-muted">
+                This category inherits all fields from its ancestors.
+              </p>
+            </div>
           </div>
         </div>
 
@@ -368,6 +400,23 @@ function cancel() {
                   >
                     {{ selectedAttributes.length }} selected
                   </span>
+                </div>
+
+                <div
+                  v-if="inheritedAttributes.length"
+                  class="mb-5 space-y-2 rounded-xl border border-attic-200 bg-attic-50/60 p-4 dark:border-attic-800 dark:bg-attic-950/20"
+                >
+                  <p class="text-xs font-bold uppercase tracking-wider text-attic-600 dark:text-attic-300">
+                    Inherited fields
+                  </p>
+                  <div
+                    v-for="assignment in inheritedAttributes"
+                    :key="assignment.attribute_id"
+                    class="flex items-center justify-between text-sm"
+                  >
+                    <span class="font-semibold text-mist-800 dark:text-mist-100">{{ assignment.attribute?.name || getAttribute(assignment.attribute_id)?.name }}</span>
+                    <span class="text-xs text-muted">{{ assignment.required ? 'Required' : 'Optional' }}</span>
+                  </div>
                 </div>
 
                 <!-- Selected Attributes -->

--- a/frontend/app/pages/plugins.vue
+++ b/frontend/app/pages/plugins.vue
@@ -46,6 +46,10 @@ function getPluginStatus(plugin: Plugin): 'active' | 'disabled' {
   return plugin.enabled ? 'active' : 'disabled'
 }
 
+function isIGDBPlugin(plugin: Plugin): boolean {
+  return plugin.id === 'igdb_games' || plugin.name.toLowerCase() === 'igdb'
+}
+
 // Get attribute color based on index for visual variety
 function getAttributeStyle(index: number): { bg: string, text: string, border: string } {
   const styles = [
@@ -270,6 +274,45 @@ function getAttributeStyle(index: number): { bg: string, text: string, border: s
               <p class="text-xs text-amber-700 dark:text-amber-300">
                 {{ plugin.disabled_reason }}
               </p>
+            </div>
+          </div>
+
+          <!-- IGDB setup instructions -->
+          <div
+            v-if="isIGDBPlugin(plugin) && !plugin.enabled"
+            class="mb-4 rounded-xl border border-attic-200 bg-attic-50/70 p-4 dark:border-attic-500/30 dark:bg-attic-500/10"
+          >
+            <div class="flex items-start gap-2.5">
+              <UIcon
+                name="i-lucide-key-round"
+                class="mt-0.5 size-4 shrink-0 text-attic-500"
+              />
+              <div class="min-w-0 space-y-2.5">
+                <div>
+                  <h4 class="text-xs font-extrabold text-mist-950 dark:text-white">
+                    Connect IGDB
+                  </h4>
+                  <p class="mt-1 text-xs leading-5 text-muted">
+                    IGDB uses Twitch application credentials. Create a Twitch application to get both values, then add them to your Attic server.
+                  </p>
+                </div>
+                <ol class="list-decimal space-y-1 pl-4 text-xs leading-5 text-muted">
+                  <li>
+                    Open the
+                    <a
+                      href="https://dev.twitch.tv/console/apps"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      class="font-bold text-attic-600 underline decoration-attic-300 underline-offset-2 hover:text-attic-700 dark:text-attic-300 dark:hover:text-attic-200"
+                    >Twitch Developer Console</a>.
+                  </li>
+                  <li>Register an application and copy its <strong class="font-bold text-mist-700 dark:text-mist-200">Client ID</strong> and <strong class="font-bold text-mist-700 dark:text-mist-200">Client Secret</strong>.</li>
+                  <li>Set <code class="rounded bg-white/80 px-1 py-0.5 font-mono text-[11px] text-mist-700 dark:bg-mist-800 dark:text-mist-200">ATTIC_IGDB_CLIENT_ID</code> and <code class="rounded bg-white/80 px-1 py-0.5 font-mono text-[11px] text-mist-700 dark:bg-mist-800 dark:text-mist-200">ATTIC_IGDB_CLIENT_SECRET</code>, then restart Attic.</li>
+                </ol>
+                <p class="text-[11px] leading-4 text-muted">
+                  Keep the Client Secret private. Attic exchanges it for a short-lived access token and stores that token only in memory.
+                </p>
+              </div>
             </div>
           </div>
 

--- a/frontend/app/types/api.ts
+++ b/frontend/app/types/api.ts
@@ -26,6 +26,7 @@ export interface CategoryAttribute {
   sort_order: number
   created_at: string
   attribute?: Attribute
+  inherited?: boolean
 }
 
 export interface Category {
@@ -39,6 +40,7 @@ export interface Category {
   created_at: string
   updated_at: string
   attributes?: CategoryAttribute[]
+  children?: Category[]
 }
 
 export interface Location {

--- a/frontend/app/utils/categoryHierarchy.ts
+++ b/frontend/app/utils/categoryHierarchy.ts
@@ -1,0 +1,97 @@
+import type { Category, CategoryAttribute } from '~/types/api'
+
+export interface CategoryOption {
+  label: string
+  value: string
+  icon?: string
+}
+
+export interface CategoryTreeRow {
+  category: Category
+  ancestors: Category[]
+  depth: number
+  rootId: string
+  childCount: number
+}
+
+export function buildCategoryTreeRows(categories: Category[], excludedIds = new Set<string>()): CategoryTreeRow[] {
+  const byId = new Map(categories.map(category => [category.id, category]))
+  const children = new Map<string | undefined, Category[]>()
+  for (const category of categories) {
+    const parentId = category.parent_id && byId.has(category.parent_id)
+      ? category.parent_id
+      : undefined
+    const siblings = children.get(parentId) || []
+    siblings.push(category)
+    children.set(parentId, siblings)
+  }
+
+  const rows: CategoryTreeRow[] = []
+  const visited = new Set<string>()
+  function visit(category: Category, ancestors: Category[]) {
+    if (excludedIds.has(category.id) || visited.has(category.id)) return
+    visited.add(category.id)
+    rows.push({
+      category,
+      ancestors,
+      depth: ancestors.length,
+      rootId: ancestors[0]?.id || category.id,
+      childCount: (children.get(category.id) || []).filter(child => !excludedIds.has(child.id)).length
+    })
+    for (const child of [...(children.get(category.id) || [])].sort((a, b) => a.name.localeCompare(b.name))) {
+      visit(child, [...ancestors, category])
+    }
+  }
+
+  for (const root of [...(children.get(undefined) || [])].sort((a, b) => a.name.localeCompare(b.name))) {
+    visit(root, [])
+  }
+  // Cycles cannot normally be persisted, but keep malformed legacy data visible.
+  for (const category of [...categories].sort((a, b) => a.name.localeCompare(b.name))) {
+    visit(category, [])
+  }
+  return rows
+}
+
+export function getCategoryDescendantIds(categories: Category[], categoryId: string): Set<string> {
+  const descendants = new Set<string>([categoryId])
+  let changed = true
+  while (changed) {
+    changed = false
+    for (const category of categories) {
+      if (category.parent_id && descendants.has(category.parent_id) && !descendants.has(category.id)) {
+        descendants.add(category.id)
+        changed = true
+      }
+    }
+  }
+  return descendants
+}
+
+export function buildCategoryOptions(categories: Category[], excludedIds = new Set<string>()): CategoryOption[] {
+  return buildCategoryTreeRows(categories, excludedIds).map(({ category, depth }) => {
+    const indent = depth > 0 ? `${'\u00A0'.repeat(depth * 2)}└ ` : ''
+    return { label: `${indent}${category.name}`, value: category.id, icon: category.icon }
+  })
+}
+
+export function getInheritedCategoryAttributes(categories: Category[], parentId?: string): CategoryAttribute[] {
+  if (!parentId) return []
+  const byId = new Map(categories.map(category => [category.id, category]))
+  const ancestry: Category[] = []
+  const visited = new Set<string>()
+  let current = byId.get(parentId)
+  while (current && !visited.has(current.id)) {
+    ancestry.unshift(current)
+    visited.add(current.id)
+    current = current.parent_id ? byId.get(current.parent_id) : undefined
+  }
+
+  const closestAssignment = new Map<string, CategoryAttribute>()
+  for (const category of ancestry) {
+    for (const assignment of category.attributes || []) {
+      closestAssignment.set(assignment.attribute_id, { ...assignment, inherited: true })
+    }
+  }
+  return [...closestAssignment.values()]
+}

--- a/frontend/tests/components/AssetCategoryField.test.ts
+++ b/frontend/tests/components/AssetCategoryField.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest'
+import { mountSuspended } from '@nuxt/test-utils/runtime'
+import type { Category } from '../../app/types/api'
+import AssetCategoryField from '../../app/components/AssetCategoryField.vue'
+
+function category(id: string, name: string, parentId?: string): Category {
+  return {
+    id,
+    organization_id: 'org',
+    name,
+    parent_id: parentId,
+    created_at: '',
+    updated_at: '',
+    attributes: []
+  }
+}
+
+describe('AssetCategoryField', () => {
+  it('explains a selected category path and its inherited fields', async () => {
+    const electronics = category('electronics', 'Electronics')
+    const computers = category('computers', 'Computers', 'electronics')
+    const laptops = category('laptops', 'Laptops', 'computers')
+    const selected = {
+      ...laptops,
+      attributes: [
+        { id: 'own', category_id: 'laptops', attribute_id: 'screen', required: false, sort_order: 0, created_at: '' },
+        { id: 'parent', category_id: 'electronics', attribute_id: 'brand', required: true, sort_order: 1, created_at: '', inherited: true }
+      ]
+    }
+
+    const wrapper = await mountSuspended(AssetCategoryField, {
+      props: {
+        modelValue: 'laptops',
+        categories: [electronics, computers, laptops],
+        selectedCategory: selected
+      }
+    })
+
+    expect(wrapper.text()).toContain('Electronics / Computers')
+    expect(wrapper.text()).toContain('Laptops')
+    expect(wrapper.text()).toContain('1 own')
+    expect(wrapper.text()).toContain('1 inherited')
+    expect(wrapper.text()).toContain('2 fields to complete')
+  })
+})

--- a/frontend/tests/components/AssetCollectionsField.test.ts
+++ b/frontend/tests/components/AssetCollectionsField.test.ts
@@ -26,6 +26,26 @@ describe('AssetCollectionsField', () => {
     wrapper.unmount()
   })
 
+  it('places the concise management link in the field header and opens it in a new tab', async () => {
+    const wrapper = await mountSuspended(AssetCollectionsField, { props: { modelValue: [] } })
+    const link = wrapper.get('a[href="/collections"]')
+
+    expect(link.text()).toBe('Manage collections')
+    expect(link.attributes('target')).toBe('_blank')
+    expect(wrapper.text()).not.toContain('opens in a new tab')
+    wrapper.unmount()
+  })
+
+  it('uses the same large, icon-led picker treatment as the category field', async () => {
+    const wrapper = await mountSuspended(AssetCollectionsField, { props: { modelValue: [] } })
+    const picker = wrapper.getComponent({ name: 'USelectMenu' })
+
+    expect(picker.props('placeholder')).toBe('Search and choose a collection')
+    expect(picker.props('icon')).toBe('i-lucide-library')
+    expect(picker.props('size')).toBe('lg')
+    wrapper.unmount()
+  })
+
   it('preserves selections when loading fails and offers retry', async () => {
     api.mockReturnValue({ data: ref(null), status: ref('error'), error: ref(new Error('offline')), refresh })
     const wrapper = await mountSuspended(AssetCollectionsField, { props: { modelValue: ['games'] } })

--- a/frontend/tests/pages/asset-sections.test.ts
+++ b/frontend/tests/pages/asset-sections.test.ts
@@ -4,6 +4,7 @@ import { flushPromises } from '@vue/test-utils'
 import { nextTick, ref } from 'vue'
 import EditAsset from '../../app/pages/assets/[id]/edit.vue'
 import NewAsset from '../../app/pages/assets/new.vue'
+import AssetCategoryField from '../../app/components/AssetCategoryField.vue'
 
 const { api, mutate, toast } = vi.hoisted(() => ({ api: vi.fn(), mutate: vi.fn(), toast: vi.fn() }))
 mockNuxtImport('useApi', () => api)
@@ -79,13 +80,31 @@ describe('Asset form sections', () => {
       : undefined)
     const wrapper = await mountSuspended(EditAsset)
     await nextTick()
-    await wrapper.get('input[name="category"]').setValue()
+    wrapper.getComponent(AssetCategoryField).vm.$emit('update:modelValue', undefined)
+    await nextTick()
     await wrapper.get('form').trigger('submit')
     await flushPromises()
     const updateCall = mutate.mock.calls.find(([url]) => url === '/api/assets/asset')!
     const payload = JSON.parse(updateCall[1].body)
     expect(payload).not.toHaveProperty('category_id')
     expect(payload).not.toHaveProperty('attributes')
+    wrapper.unmount()
+  })
+
+  it('loads category fields when categorizing an uncategorized asset while editing', async () => {
+    mutate.mockImplementation(async (url: string) => url === '/api/categories/games?inherited=true'
+      ? {
+          id: 'games',
+          name: 'Games',
+          attributes: [{ attribute_id: 'platform', attribute: { key: 'platform', name: 'Platform', data_type: 'string' } }]
+        }
+      : undefined)
+    const wrapper = await mountSuspended(EditAsset)
+
+    wrapper.getComponent(AssetCategoryField).vm.$emit('update:modelValue', 'games')
+    await flushPromises()
+
+    expect(mutate).toHaveBeenCalledWith('/api/categories/games?inherited=true')
     wrapper.unmount()
   })
 })

--- a/frontend/tests/utils/categoryHierarchy.test.ts
+++ b/frontend/tests/utils/categoryHierarchy.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from 'vitest'
+import type { Category } from '../../app/types/api'
+import {
+  buildCategoryOptions,
+  buildCategoryTreeRows,
+  getCategoryDescendantIds,
+  getInheritedCategoryAttributes
+} from '../../app/utils/categoryHierarchy'
+
+function category(id: string, name: string, parentId?: string): Category {
+  return {
+    id,
+    organization_id: 'org',
+    name,
+    parent_id: parentId,
+    created_at: '',
+    updated_at: '',
+    attributes: []
+  }
+}
+
+describe('categoryHierarchy', () => {
+  it('orders and indents categories by ancestry', () => {
+    const categories = [
+      category('leaf', 'Ultrabooks', 'child'),
+      category('root', 'Hardware'),
+      category('child', 'Computers', 'root'),
+      category('other', 'Books')
+    ]
+
+    expect(buildCategoryOptions(categories).map(option => option.label)).toEqual([
+      'Books',
+      'Hardware',
+      '\u00A0\u00A0└ Computers',
+      '\u00A0\u00A0\u00A0\u00A0└ Ultrabooks'
+    ])
+  })
+
+  it('exposes ancestry and child counts for a tree view', () => {
+    const rows = buildCategoryTreeRows([
+      category('leaf', 'Ultrabooks', 'child'),
+      category('root', 'Hardware'),
+      category('child', 'Computers', 'root')
+    ])
+
+    expect(rows.map(row => ({
+      name: row.category.name,
+      depth: row.depth,
+      ancestors: row.ancestors.map(ancestor => ancestor.name),
+      children: row.childCount
+    }))).toEqual([
+      { name: 'Hardware', depth: 0, ancestors: [], children: 1 },
+      { name: 'Computers', depth: 1, ancestors: ['Hardware'], children: 1 },
+      { name: 'Ultrabooks', depth: 2, ancestors: ['Hardware', 'Computers'], children: 0 }
+    ])
+  })
+
+  it('finds every descendant for safe parent selection', () => {
+    const categories = [
+      category('root', 'Hardware'),
+      category('child', 'Computers', 'root'),
+      category('leaf', 'Ultrabooks', 'child'),
+      category('other', 'Books')
+    ]
+
+    expect([...getCategoryDescendantIds(categories, 'root')].sort()).toEqual(['child', 'leaf', 'root'])
+  })
+
+  it('inherits ancestor assignments and lets the nearest ancestor win', () => {
+    const root = category('root', 'Hardware')
+    root.attributes = [
+      { id: 'ca-root', category_id: 'root', attribute_id: 'vendor', required: true, sort_order: 0, created_at: '' }
+    ]
+    const child = category('child', 'Computers', 'root')
+    child.attributes = [
+      { id: 'ca-child', category_id: 'child', attribute_id: 'vendor', required: false, sort_order: 1, created_at: '' },
+      { id: 'ca-model', category_id: 'child', attribute_id: 'model', required: true, sort_order: 0, created_at: '' }
+    ]
+
+    const inherited = getInheritedCategoryAttributes([root, child], 'child')
+    expect(inherited.map(assignment => assignment.attribute_id)).toEqual(['vendor', 'model'])
+    expect(inherited[0]).toMatchObject({ category_id: 'child', required: false, inherited: true })
+  })
+})


### PR DESCRIPTION
## Summary

 Fixes #55 

  Categories can now be nested again, with fields inherited through the category hierarchy.

  ## What changed

  - Restored parent/child category relationships.
  - Added effective attribute resolution across ancestors.
  - Applied nearest-category precedence when attributes are overridden.
  - Added validation for parent organization and cyclic relationships.
  - Added inherited fields to asset creation and editing.
  - Updated category filtering and asset counts to include descendants.
  - Reworked the Categories page into an explicit tree view.
  - Added ancestry-aware, searchable category selection to asset forms.
  - Improved inherited/own field summaries and collection picker consistency.

  ## API

  - Existing category responses remain direct-assignment based by default.
  - Use `?inherited=true` to retrieve effective inherited attributes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Categories now support parent-child hierarchies and inherited custom fields.
  * Asset forms display category paths, inherited fields, completion status, and loading states.
  * Category management includes hierarchical browsing, parent selection, ancestry-aware search, and field origin details.
  * Category filters include assets assigned to descendant categories, and asset totals reflect descendants.
  * Added setup guidance for disabled IGDB plugins.
* **Bug Fixes**
  * Prevented invalid category parent relationships and rejected assets missing required category fields.
* **UI Improvements**
  * Updated collections picker presentation and management link behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->