### PR TITLE
fix: show API validation details when saving assets

### DIFF
--- a/frontend/app/pages/assets/[id]/edit.vue
+++ b/frontend/app/pages/assets/[id]/edit.vue
@@ -230,9 +230,9 @@ async function submitForm() {
     toast.add({ title: 'Asset updated successfully', color: 'success' })
     router.push(`/assets/${route.params.id}`)
   } catch (err: unknown) {
-    const error = err as { message?: string }
+    const error = err as { data?: { error?: string }, message?: string }
     toast.add({
-      title: error?.message || 'Failed to update asset',
+      title: error?.data?.error || error?.message || 'Failed to update asset',
       color: 'error'
     })
   } finally {

--- a/frontend/app/pages/assets/new.vue
+++ b/frontend/app/pages/assets/new.vue
@@ -175,8 +175,8 @@ async function submitForm() {
     toast.add({ title: 'Asset created successfully', color: 'success' })
     router.push(`/assets/${response.id}`)
   } catch (err: unknown) {
-    const error = err as { message?: string }
-    toast.add({ title: error?.message || 'Failed to create asset', color: 'error' })
+    const error = err as { data?: { error?: string }, message?: string }
+    toast.add({ title: error?.data?.error || error?.message || 'Failed to create asset', color: 'error' })
   } finally {
     loading.value = false
   }

--- a/frontend/tests/pages/asset-sections.test.ts
+++ b/frontend/tests/pages/asset-sections.test.ts
@@ -33,6 +33,50 @@ describe('Asset form sections', () => {
     wrapper.unmount()
   })
 
+  describe.each([
+    ['create', NewAsset, 'Failed to create asset'],
+    ['edit', EditAsset, 'Failed to update asset']
+  ] as const)('%s save errors', (mode, component, fallback) => {
+    it.each([
+      [
+        { data: { error: 'required category attributes are missing: Serial number' }, message: '[PUT] /api/assets/asset: 400 Bad Request' },
+        'required category attributes are missing: Serial number'
+      ],
+      [new Error('Network unavailable'), 'Network unavailable'],
+      [{}, fallback]
+    ])('shows the useful error message for %j', async (error, expected) => {
+      mutate.mockImplementation(async (url: string) => {
+        if (url.startsWith('/api/categories/')) {
+          return {
+            id: 'electronics',
+            name: 'Electronics',
+            attributes: [{
+              attribute_id: 'serial', required: true,
+              attribute: { key: 'serial', name: 'Serial number', data_type: 'string' }
+            }]
+          }
+        }
+        throw error
+      })
+      if (mode === 'edit') asset.value = { ...asset.value, category_id: 'electronics' }
+      const wrapper = await mountSuspended(component)
+      if (mode === 'create') {
+        await wrapper.get('#asset-name').setValue('Desk')
+        wrapper.getComponent(AssetCategoryField).vm.$emit('update:modelValue', 'electronics')
+      }
+      await flushPromises()
+      await wrapper.get('form').trigger('submit')
+      await flushPromises()
+
+      expect(mutate).toHaveBeenCalledWith(
+        mode === 'create' ? '/api/assets' : '/api/assets/asset',
+        expect.objectContaining({ method: mode === 'create' ? 'POST' : 'PUT' })
+      )
+      expect(toast).toHaveBeenCalledExactlyOnceWith({ title: expected, color: 'error' })
+      wrapper.unmount()
+    })
+  })
+
   it.each([
     [{}, false, false],
     [{ description: '  ', notes: '\n', purchase_note: ' ' }, false, false],


### PR DESCRIPTION
Fixes #60.

When an asset is missing a required category attribute, the create and edit forms now show the API's `data.error` message (including the missing field's name) instead of the generic HTTP request error. Network-error messages and the existing fallback text still work.

Added six component cases that submit the actual create/edit forms and check validation, network, and empty-error responses. The two validation cases fail on the original code and pass with this change.

Validation: all 310 frontend tests pass; `bun run lint`, `bun run typecheck`, and `bun run build` pass.

Implemented and locally validated with OpenAI Codex.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Asset creation and editing now display clearer server-provided validation errors when available.
  - Network and unknown errors continue to show appropriate fallback messages.

- **Tests**
  - Added coverage for asset creation and editing error scenarios, including API validation, network, and unknown errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->