### PR TITLE
fix(categories): preserve draft when creating attributes

### DIFF
--- a/frontend/app/pages/attributes/new.vue
+++ b/frontend/app/pages/attributes/new.vue
@@ -4,8 +4,24 @@ definePageMeta({
 })
 
 const router = useRouter()
+const route = useRoute()
 const toast = useToast()
 const apiFetch = useApiFetch()
+const returnToCategory = route.query.returnTo === 'category'
+
+function returnAfterAttribute(attributeID?: string) {
+  if (returnToCategory) {
+    router.push({
+      path: '/categories/new',
+      query: {
+        resume: 'attribute',
+        ...(attributeID ? { attribute_id: attributeID } : {})
+      }
+    })
+    return
+  }
+  router.push('/attributes')
+}
 
 // Form state
 const form = reactive({
@@ -101,7 +117,7 @@ async function saveAttribute() {
 
   saving.value = true
   try {
-    await apiFetch('/api/attributes', {
+    const attribute = await apiFetch<{ id: string }>('/api/attributes', {
       method: 'POST',
       body: JSON.stringify({
         name: form.name,
@@ -111,7 +127,7 @@ async function saveAttribute() {
     })
 
     toast.add({ title: 'Attribute created successfully', color: 'success' })
-    router.push('/attributes')
+    returnAfterAttribute(attribute.id)
   } catch {
     toast.add({ title: 'Failed to create attribute', color: 'error' })
   } finally {
@@ -121,7 +137,7 @@ async function saveAttribute() {
 
 // Cancel and go back
 function cancel() {
-  router.push('/attributes')
+  returnAfterAttribute()
 }
 </script>
 

--- a/frontend/app/pages/categories/new.vue
+++ b/frontend/app/pages/categories/new.vue
@@ -12,25 +12,41 @@ const route = useRoute()
 const toast = useToast()
 const apiFetch = useApiFetch()
 
-const { data: attributes } = useApi<Attribute[]>('/api/attributes')
+const { data: attributes, refresh: refreshAttributes } = useApi<Attribute[]>('/api/attributes')
 const { data: categories } = useApi<Category[]>('/api/categories')
 
 // Form state
-const form = reactive({
-  name: '',
-  description: '',
-  icon: 'i-lucide-tag',
-  parent_id: typeof route.query.parent_id === 'string' ? route.query.parent_id : undefined
-})
+interface CategoryDraft {
+  form: {
+    name: string
+    description: string
+    icon: string
+    parent_id?: string
+  }
+  selectedAttributes: AttributeSelection[]
+}
 
-// Attribute selection
 interface AttributeSelection {
   attribute_id: string
   required: boolean
   sort_order: number
 }
 
-const selectedAttributes = ref<AttributeSelection[]>([])
+const categoryDraft = useState<CategoryDraft | null>('new-category-draft', () => null)
+const restoreDraft = route.query.resume === 'attribute'
+const restoredDraft = restoreDraft ? categoryDraft.value : null
+
+const form = reactive({
+  name: restoredDraft?.form.name || '',
+  description: restoredDraft?.form.description || '',
+  icon: restoredDraft?.form.icon || 'i-lucide-tag',
+  parent_id: restoredDraft?.form.parent_id
+    || (typeof route.query.parent_id === 'string' ? route.query.parent_id : undefined)
+})
+
+// Attribute selection
+const selectedAttributes = ref<AttributeSelection[]>(restoredDraft?.selectedAttributes.map(attribute => ({ ...attribute })) || [])
+categoryDraft.value = null
 const parentOptions = computed(() => [
   { label: 'None (Top Level)', value: undefined },
   ...buildCategoryOptions(categories.value || [])
@@ -133,11 +149,31 @@ function getAttribute(id: string): Attribute | undefined {
 
 // Add attribute to selection
 function addAttribute(attr: Attribute) {
+  if (selectedAttributes.value.some(selection => selection.attribute_id === attr.id)) return
   selectedAttributes.value.push({
     attribute_id: attr.id,
     required: false,
     sort_order: selectedAttributes.value.length
   })
+}
+
+async function restoreCreatedAttribute() {
+  const attributeID = route.query.attribute_id
+  if (!restoreDraft || typeof attributeID !== 'string') return
+
+  await refreshAttributes()
+  const attribute = getAttribute(attributeID)
+  if (attribute) addAttribute(attribute)
+}
+
+onMounted(restoreCreatedAttribute)
+
+function createAttribute() {
+  categoryDraft.value = {
+    form: { ...form },
+    selectedAttributes: selectedAttributes.value.map(attribute => ({ ...attribute }))
+  }
+  router.push({ path: '/attributes/new', query: { returnTo: 'category' } })
 }
 
 // Remove attribute from selection
@@ -189,6 +225,7 @@ async function saveCategory() {
     })
 
     toast.add({ title: 'Category created successfully', color: 'success' })
+    categoryDraft.value = null
     router.push('/categories')
   } catch {
     toast.add({ title: 'Failed to create category', color: 'error' })
@@ -199,6 +236,7 @@ async function saveCategory() {
 
 // Cancel and go back
 function cancel() {
+  categoryDraft.value = null
   router.push('/categories')
 }
 </script>
@@ -373,16 +411,17 @@ function cancel() {
                 </p>
               </div>
             </div>
-            <NuxtLink
-              to="/attributes"
+            <button
+              type="button"
               class="text-sm font-semibold text-attic-500 hover:text-attic-600 flex items-center gap-1 px-3 py-1.5 rounded-lg hover:bg-attic-500/5 transition-colors"
+              @click="createAttribute"
             >
               <UIcon
                 name="i-lucide-plus-circle"
                 class="w-4 h-4"
               />
               New Attribute
-            </NuxtLink>
+            </button>
           </div>
 
           <!-- Composer Body: Split View -->

--- a/frontend/tests/pages/category-attribute-flow.test.ts
+++ b/frontend/tests/pages/category-attribute-flow.test.ts
@@ -1,0 +1,110 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { mountSuspended, mockNuxtImport } from '@nuxt/test-utils/runtime'
+import { flushPromises } from '@vue/test-utils'
+import { ref } from 'vue'
+import NewCategory from '../../app/pages/categories/new.vue'
+import NewAttribute from '../../app/pages/attributes/new.vue'
+
+const { api, mutate, push, replace, resolve, toast, route, draft } = vi.hoisted(() => ({
+  api: vi.fn(),
+  mutate: vi.fn(),
+  push: vi.fn(),
+  replace: vi.fn(),
+  resolve: vi.fn((to: string | { path: string }) => ({ href: typeof to === 'string' ? to : to.path })),
+  toast: vi.fn(),
+  route: { query: {} as Record<string, string> },
+  draft: { value: null as Record<string, unknown> | null }
+}))
+
+mockNuxtImport('useApi', () => api)
+mockNuxtImport('useApiFetch', () => () => mutate)
+mockNuxtImport('useRouter', () => () => ({ push, replace, resolve }))
+mockNuxtImport('useRoute', () => () => route)
+mockNuxtImport('useToast', () => () => ({ add: toast }))
+mockNuxtImport('useState', () => () => draft)
+
+describe('creating an attribute from a category draft', () => {
+  const attributes = ref<Record<string, unknown>[]>([])
+  const refreshAttributes = vi.fn()
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    route.query = {}
+    draft.value = null
+    attributes.value = []
+    api.mockImplementation((url: string) => url === '/api/attributes'
+      ? { data: attributes, refresh: refreshAttributes }
+      : { data: ref([]) })
+    mutate.mockResolvedValue({ id: 'new-attribute' })
+  })
+
+  it('keeps the category draft when opening the attribute form', async () => {
+    const wrapper = await mountSuspended(NewCategory)
+    await wrapper.get('input[placeholder="e.g. Rare Books"]').setValue('Vintage cameras')
+    await wrapper.get('textarea').setValue('Analog photography gear')
+    const newAttribute = wrapper.findAll('button').find(button => button.text().includes('New Attribute'))!
+    await newAttribute.trigger('click')
+
+    expect(draft.value).toMatchObject({
+      form: { name: 'Vintage cameras', description: 'Analog photography gear' },
+      selectedAttributes: []
+    })
+    expect(push).toHaveBeenCalledWith({ path: '/attributes/new', query: { returnTo: 'category' } })
+    wrapper.unmount()
+  })
+
+  it('returns to the category draft and identifies the created attribute', async () => {
+    route.query = { returnTo: 'category' }
+    const wrapper = await mountSuspended(NewAttribute)
+    await wrapper.get('input[placeholder="e.g. Purchase Date"]').setValue('Serial number')
+    const save = wrapper.findAll('button').find(button => button.text().includes('Save Attribute'))!
+    await save.trigger('click')
+    await flushPromises()
+
+    expect(push).toHaveBeenCalledWith({
+      path: '/categories/new',
+      query: { resume: 'attribute', attribute_id: 'new-attribute' }
+    })
+    wrapper.unmount()
+  })
+
+  it('restores entered values and selects the newly created attribute', async () => {
+    route.query = { resume: 'attribute', attribute_id: 'new-attribute' }
+    draft.value = {
+      form: {
+        name: 'Vintage cameras',
+        description: 'Analog photography gear',
+        icon: 'i-lucide-camera'
+      },
+      selectedAttributes: [{ attribute_id: 'existing', required: true, sort_order: 0 }]
+    }
+    attributes.value = [
+      { id: 'existing', name: 'Maker', key: 'maker', data_type: 'string' },
+      { id: 'new-attribute', name: 'Serial number', key: 'serial_number', data_type: 'string' }
+    ]
+
+    const wrapper = await mountSuspended(NewCategory)
+    await flushPromises()
+
+    expect((wrapper.get('input[placeholder="e.g. Rare Books"]').element as HTMLInputElement).value).toBe('Vintage cameras')
+    expect((wrapper.get('textarea').element as HTMLTextAreaElement).value).toBe('Analog photography gear')
+    expect(wrapper.text()).toContain('Maker')
+    expect(wrapper.text()).toContain('Serial number')
+    expect(refreshAttributes).toHaveBeenCalledOnce()
+    expect(draft.value).toBeNull()
+    wrapper.unmount()
+  })
+
+  it('returns to the draft when attribute creation is cancelled', async () => {
+    route.query = { returnTo: 'category' }
+    const wrapper = await mountSuspended(NewAttribute)
+    const cancel = wrapper.findAll('button').find(button => button.text() === 'Cancel')!
+    await cancel.trigger('click')
+
+    expect(push).toHaveBeenCalledWith({
+      path: '/categories/new',
+      query: { resume: 'attribute' }
+    })
+    wrapper.unmount()
+  })
+})


### PR DESCRIPTION
## Summary

  Fixes #66 .

When creating a category, users can now create a new attribute without losing their category draft.

### Changes

- Open the attribute creation form directly from category creation.
- Preserve category fields and selected attributes during the detour.
- Return to category creation after saving or cancelling.
- Automatically select the newly created attribute.
- Clear the temporary draft after restoration, save, or cancellation.
- Add regression tests for the complete flow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Creating an attribute from the new category form now preserves the category draft.
  - After attribute creation or cancellation, users return to the category form.
  - The newly created attribute is automatically added to the category.
  - Draft values and selected attributes are restored when returning to the category form.

- **Tests**
  - Added coverage for the category and attribute creation workflow, including cancellation and draft restoration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->