### PR TITLE
fix(frontend): refresh data after category and asset mutations

### DIFF
--- a/frontend/app/pages/assets/[id]/edit.vue
+++ b/frontend/app/pages/assets/[id]/edit.vue
@@ -11,8 +11,10 @@ const router = useRouter()
 const toast = useToast()
 const apiFetch = useApiFetch()
 
-const { data: asset, status: assetStatus } = useApi<Asset>(
-  () => `/api/assets/${route.params.id}`
+const assetUrl = computed(() => `/api/assets/${route.params.id}`)
+const { data: asset, status: assetStatus, clear: clearAsset } = useApi<Asset>(
+  () => assetUrl.value,
+  { key: assetUrl }
 )
 const { data: categories } = useApi<Category[]>('/api/categories')
 const { data: locations } = useApi<Location[]>('/api/locations')
@@ -227,6 +229,7 @@ async function submitForm() {
       body: JSON.stringify(payload)
     })
 
+    clearAsset()
     toast.add({ title: 'Asset updated successfully', color: 'success' })
     router.push(`/assets/${route.params.id}`)
   } catch (err: unknown) {

--- a/frontend/app/pages/assets/[id]/index.vue
+++ b/frontend/app/pages/assets/[id]/index.vue
@@ -10,7 +10,11 @@ const router = useRouter()
 const toast = useToast()
 const apiFetch = useApiFetch()
 
-const { data: asset, refresh: refreshAsset } = useApi<Asset>(() => `/api/assets/${route.params.id}`)
+const assetUrl = computed(() => `/api/assets/${route.params.id}`)
+const { data: asset, refresh: refreshAsset } = useApi<Asset>(
+  () => assetUrl.value,
+  { key: assetUrl }
+)
 const { data: warranty, refresh: refreshWarranty } = useApi<Warranty>(() => `/api/assets/${route.params.id}/warranty`)
 const { data: attachments, refresh: refreshAttachments } = useApi<Attachment[]>(
   () => `/api/assets/${route.params.id}/attachments`

--- a/frontend/app/pages/categories/new.vue
+++ b/frontend/app/pages/categories/new.vue
@@ -13,7 +13,7 @@ const toast = useToast()
 const apiFetch = useApiFetch()
 
 const { data: attributes, refresh: refreshAttributes } = useApi<Attribute[]>('/api/attributes')
-const { data: categories } = useApi<Category[]>('/api/categories')
+const { data: categories, clear: clearCategories } = useApi<Category[]>('/api/categories')
 
 // Form state
 interface CategoryDraft {
@@ -224,6 +224,7 @@ async function saveCategory() {
       })
     })
 
+    clearCategories()
     toast.add({ title: 'Category created successfully', color: 'success' })
     categoryDraft.value = null
     router.push('/categories')

--- a/frontend/tests/pages/asset-sections.test.ts
+++ b/frontend/tests/pages/asset-sections.test.ts
@@ -6,7 +6,9 @@ import EditAsset from '../../app/pages/assets/[id]/edit.vue'
 import NewAsset from '../../app/pages/assets/new.vue'
 import AssetCategoryField from '../../app/components/AssetCategoryField.vue'
 
-const { api, mutate, toast } = vi.hoisted(() => ({ api: vi.fn(), mutate: vi.fn(), toast: vi.fn() }))
+const { api, mutate, toast, clearAsset } = vi.hoisted(() => ({
+  api: vi.fn(), mutate: vi.fn(), toast: vi.fn(), clearAsset: vi.fn()
+}))
 mockNuxtImport('useApi', () => api)
 mockNuxtImport('useApiFetch', () => () => mutate)
 mockNuxtImport('useToast', () => () => ({ add: toast }))
@@ -18,7 +20,10 @@ describe('Asset form sections', () => {
     vi.clearAllMocks()
     asset.value = { id: 'asset', name: 'Desk', quantity: 1 }
     api.mockImplementation((url: unknown) => ({
-      data: typeof url === 'function' ? asset : ref([]), status: ref('success'), error: ref(null)
+      data: typeof url === 'function' ? asset : ref([]),
+      status: ref('success'),
+      error: ref(null),
+      clear: clearAsset
     }))
     mutate.mockResolvedValue({ id: 'new-asset' })
   })
@@ -132,6 +137,7 @@ describe('Asset form sections', () => {
     const payload = JSON.parse(updateCall[1].body)
     expect(payload).not.toHaveProperty('category_id')
     expect(payload).not.toHaveProperty('attributes')
+    expect(clearAsset).toHaveBeenCalledOnce()
     wrapper.unmount()
   })
 

--- a/frontend/tests/pages/category-attribute-flow.test.ts
+++ b/frontend/tests/pages/category-attribute-flow.test.ts
@@ -5,13 +5,14 @@ import { ref } from 'vue'
 import NewCategory from '../../app/pages/categories/new.vue'
 import NewAttribute from '../../app/pages/attributes/new.vue'
 
-const { api, mutate, push, replace, resolve, toast, route, draft } = vi.hoisted(() => ({
+const { api, mutate, push, replace, resolve, toast, route, draft, clearCategories } = vi.hoisted(() => ({
   api: vi.fn(),
   mutate: vi.fn(),
   push: vi.fn(),
   replace: vi.fn(),
   resolve: vi.fn((to: string | { path: string }) => ({ href: typeof to === 'string' ? to : to.path })),
   toast: vi.fn(),
+  clearCategories: vi.fn(),
   route: { query: {} as Record<string, string> },
   draft: { value: null as Record<string, unknown> | null }
 }))
@@ -34,7 +35,7 @@ describe('creating an attribute from a category draft', () => {
     attributes.value = []
     api.mockImplementation((url: string) => url === '/api/attributes'
       ? { data: attributes, refresh: refreshAttributes }
-      : { data: ref([]) })
+      : { data: ref([]), clear: clearCategories })
     mutate.mockResolvedValue({ id: 'new-attribute' })
   })
 
@@ -50,6 +51,19 @@ describe('creating an attribute from a category draft', () => {
       selectedAttributes: []
     })
     expect(push).toHaveBeenCalledWith({ path: '/attributes/new', query: { returnTo: 'category' } })
+    wrapper.unmount()
+  })
+
+  it('clears the cached category list after creating a category', async () => {
+    const wrapper = await mountSuspended(NewCategory)
+    await wrapper.get('input[placeholder="e.g. Rare Books"]').setValue('Vintage cameras')
+    const save = wrapper.findAll('button').find(button => button.text().includes('Save Category'))!
+    await save.trigger('click')
+    await flushPromises()
+
+    expect(clearCategories).toHaveBeenCalledOnce()
+    expect(push).toHaveBeenCalledWith('/categories')
+    expect(clearCategories.mock.invocationCallOrder[0]).toBeLessThan(push.mock.invocationCallOrder[0]!)
     wrapper.unmount()
   })
 


### PR DESCRIPTION
## Summary

Fixes #59 

The UI could show stale data after successfully creating a category or updating an asset, requiring a manual browser refresh.

### Changes

- Clear the cached category list after category creation.
- Use a shared cache key for asset detail and edit pages.
- Clear the cached asset data after a successful asset update.
- Add regression coverage for mutation cache invalidation.

This uses Nuxt async-data invalidation instead of forcing a full page reload.