### PR TITLE
fix(ui): improve settings page dark mode readability

### DIFF
--- a/frontend/app/pages/settings.vue
+++ b/frontend/app/pages/settings.vue
@@ -40,7 +40,7 @@ async function save() {
 <template>
   <div class="max-w-3xl mx-auto p-6 lg:p-10 space-y-8">
     <div>
-      <h1 class="text-3xl font-black">
+      <h1 class="text-3xl font-black text-mist-950 dark:text-white">
         Settings
       </h1>
       <p class="text-muted mt-2">
@@ -55,7 +55,7 @@ async function save() {
           class="py-5 flex items-center justify-between gap-6"
         >
           <div>
-            <p class="font-bold">
+            <p class="font-bold text-mist-950 dark:text-white">
               {{ item.label }}
             </p>
             <p class="text-sm text-muted mt-1">

--- a/frontend/tests/pages/settings.test.ts
+++ b/frontend/tests/pages/settings.test.ts
@@ -48,6 +48,16 @@ describe('organization feature settings', () => {
     wrapper.unmount()
   })
 
+  it('uses readable text colors in light and dark mode', async () => {
+    const wrapper = await mountSuspended(SettingsPage)
+    const heading = wrapper.get('h1')
+    const featureLabel = wrapper.findAll('p').find(element => element.text() === 'Locations')!
+
+    expect(heading.classes()).toEqual(expect.arrayContaining(['text-mist-950', 'dark:text-white']))
+    expect(featureLabel.classes()).toEqual(expect.arrayContaining(['text-mist-950', 'dark:text-white']))
+    wrapper.unmount()
+  })
+
   it('resolves authentication before loading settings', async () => {
     authLoading.value = true
     fetchSession.mockImplementationOnce(() => {


### PR DESCRIPTION
## Summary

Closes #79 .

- Add theme-aware text colors to the settings page heading and feature labels.
- Add regression coverage for light/dark text classes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved settings page heading and feature label text contrast in light and dark modes.

* **Tests**
  * Added coverage to verify readable text colors for the settings heading and “Locations” label across both themes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->